### PR TITLE
Revert "build: add coverage"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,4 @@ jobs:
       - name: lint
         run: npm run lint
       - name: Test
-        run: npm run coverage
+        run: npm run test


### PR DESCRIPTION
This reverts commit ce680b35295d485910e29510e73c67fc31782c9f.

this commit was to test the coverage command - should not be been committed to main. :)