### PR TITLE
feat(parser): support private-field-in (stage 3)

### DIFF
--- a/src/compiler/ast/expressions/field-definition.ts
+++ b/src/compiler/ast/expressions/field-definition.ts
@@ -12,6 +12,8 @@ import { AccessModifier } from '../types/access-modifier';
  */
 export interface FieldDefinition extends Node {
   readonly key: Expression | PrivateIdentifier;
+  readonly isInKeyword: boolean;
+  readonly expression: Expression | null;
   readonly isAbstract: boolean;
   readonly isReadOnly: boolean;
   readonly isOptional: boolean;
@@ -25,6 +27,8 @@ export interface FieldDefinition extends Node {
 
 export function createFieldDefinition(
   key: Expression | PrivateIdentifier,
+  isInKeyword: boolean,
+  expression: Expression | null,
   isOptional: boolean,
   isDeclared: boolean,
   isReadOnly: boolean,
@@ -43,6 +47,8 @@ export function createFieldDefinition(
   return {
     kind: NodeKind.FieldDefinition,
     key,
+    isInKeyword,
+    expression,
     isAbstract,
     isReadOnly,
     isOptional,
@@ -63,6 +69,8 @@ export function createFieldDefinition(
 export function updateFieldDefinition(
   node: FieldDefinition,
   key: Expression | PrivateIdentifier,
+  isInKeyword: boolean,
+  expression: Expression | null,
   isOptional: boolean,
   isDeclared: boolean,
   isReadOnly: boolean,
@@ -85,6 +93,8 @@ export function updateFieldDefinition(
     ? updateNode(
         createFieldDefinition(
           key,
+          isInKeyword,
+          expression,
           isOptional,
           isDeclared,
           isReadOnly,

--- a/src/compiler/parser/index.ts
+++ b/src/compiler/parser/index.ts
@@ -4877,7 +4877,11 @@ function parseClassElement(parser: ParserState, context: Context): ClassElement 
 
   if (parser.token & 0b00000000000000000111000000000000) {
     let token = parser.token;
-    let key: any = parseIdentifierName(parser, context);
+
+    let key: any =
+      token === Token.PrivateIdentifier
+        ? parsePrivateIdentifier(parser, context)
+        : parseIdentifierName(parser, context);
 
     // Simple cases like "{ static foo(" or "{ static foo<x>(" or "{ private static set(" or
     // "{ private static constructor<x>(".
@@ -5199,6 +5203,9 @@ function parseFieldDefinition(
     }
     optional = true;
   }
+
+  const isIn = key.kind === NodeKind.PrivateIdentifier && consumeOpt(parser, context, Token.InKeyword);
+  const expression = isIn ? parseExpression(parser, context) : null;
   const exclamation = consumeOpt(parser, context, Token.Negate);
   const type = parseTypeAnnotation(parser, context);
   const initializer = parseInitializer(parser, context);
@@ -5207,6 +5214,8 @@ function parseFieldDefinition(
 
   return createFieldDefinition(
     key,
+    isIn,
+    expression,
     optional,
     isDeclared,
     isReadOnly,

--- a/src/compiler/parser/index.ts
+++ b/src/compiler/parser/index.ts
@@ -5203,8 +5203,9 @@ function parseFieldDefinition(
     }
     optional = true;
   }
-
-  const isIn = key.kind === NodeKind.PrivateIdentifier && consumeOpt(parser, context, Token.InKeyword);
+  // Only a private field - '#ch' - is allowed with the 'in' keyword, but we will handle
+  // this in the grammar checker.
+  const isIn = consumeOpt(parser, context, Token.InKeyword);
   const expression = isIn ? parseExpression(parser, context) : null;
   const exclamation = consumeOpt(parser, context, Token.Negate);
   const type = parseTypeAnnotation(parser, context);

--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -599,6 +599,8 @@ export function visitEachChild(node: any, visitor: (node: Node) => Node, context
       return updateFieldDefinition(
         node,
         visitNode(node.key, visitor),
+        node.isInKeyword,
+        node.expression,
         node.isOptional,
         node.isDeclared,
         node.isReadOnly,


### PR DESCRIPTION
cc / @aladdin-add Can you add a few tests?

It's already works for the printer. [Click here for a preview](https://kataw.github.io/kataw/kataw_print/?code=class%20C%20%7B%0A%20%23field%20in%20()%20%3D%3E%20%7B%7D%3B%0A%7D&method=parse&range=undefined&loc=false&next=false&cst=false&module=false&raw=undefined&jsx=undefined&directives=undefined&attachComment=undefined&webCompat=undefined&lexical=undefined)