### PR TITLE
chore: WIP! Add linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,22 @@ If you want a `1:1` copy of the actual source code, you can do a "*slice*" from 
 
 - Performance
 
+
+## Linter
+
+Kataw's linter is still `WIP` and it is using an different approach than for example ESLint to maintain performance.
+
+An `autoFix` option can be set during the parsing and the parser will try to fix as much errors as possible. If not
+fixable - you will be notified through the advanced diagnostic system.
+
+The linter options can be set as part of the parser options like this:
+
+```ts
+kataw.parseScript('switch(x) {}', { linterOptions: { switchDefault: true} }, function() {});
+
+// A 'default' clause is required
+```
+
 ## Current state
 
 - The CST parser can be used in production

--- a/src/diagnostic/diagnostic-code.ts
+++ b/src/diagnostic/diagnostic-code.ts
@@ -239,7 +239,8 @@ export const enum DiagnosticCode {
   Comma_operator_is_disallowed_as_an_async_arrow_concise_body_with_export_default_modifier = 242,
   _MethodDefinition_expected = 243,
   A_class_field_cannot_have_a_field_named_constructor = 244,
-  Class_fields_may_not_have_a_static_property_named_prototype = 245
+  Class_fields_may_not_have_a_static_property_named_prototype = 245,
+  A_default_clause_is_required = 246
 }
 
 export const diagnosticMap: { [key: number]: string } = {
@@ -483,5 +484,6 @@ export const diagnosticMap: { [key: number]: string } = {
   [242]: 'Comma operator is disallowed as an async arrow concise body with `export default` modifier',
   [243]: '`MethodDefinition` expected',
   [244]: "A class field cannot have a field named 'constructor'",
-  [245]: "Class fields may not have a static property named 'prototype'"
+  [245]: "Class fields may not have a static property named 'prototype'",
+  [246]: "A 'default' clause is required"
 };

--- a/src/diagnostic/diagnostic.ts
+++ b/src/diagnostic/diagnostic.ts
@@ -22,6 +22,7 @@ export enum DiagnosticKind {
   Warning = 1 << 3,
   Error = 1 << 4,
   Hint = 1 << 5,
+  Linter = 1 << 6
 }
 
 /**

--- a/src/diagnostic/diagnosticMessages.json
+++ b/src/diagnostic/diagnosticMessages.json
@@ -236,7 +236,8 @@
   "Comma operator is disallowed as an async arrow concise body with `export default` modifier": 242,
   "`MethodDefinition` expected": 243,
   "A class field cannot have a field named 'constructor'": 244,
-  "Class fields may not have a static property named 'prototype'": 245
+  "Class fields may not have a static property named 'prototype'": 245,
+  "A 'default' clause is required": 246
 }
 
 

--- a/src/parser/common.ts
+++ b/src/parser/common.ts
@@ -62,8 +62,17 @@ export const enum Context {
   DecoratorContext = 1 << 27
 }
 
-export const enum Linter {
-  SwitchDefault = 1 << 0
+export const enum LinterFlags {
+  None = 0,
+  SwitchDefault = 1 << 0, // require switch default
+  NoCommaOperator = 1 << 1, // disallow comma
+  NoCatchAssign = 1 << 2, // disallow catch assign
+  NoDebugger = 1 << 3, // no debugger
+  NoEmptyBlocks = 1 << 4, // no empty block
+  NoNestedTernary = 1 << 5, // no nested ternary
+  NoSparseArray = 1 << 6, // no sparse array
+  NoEmpty = 1 << 7, // disallow empty block statements
+  noExtraParens = 1 << 8 // disallow unnecessary parentheses
 }
 
 export const enum DestructibleKind {
@@ -149,6 +158,7 @@ export const enum ScopeFlags {
 export interface ParserState {
   source: string;
   nodeFlags: NodeFlags;
+  linterFlags: LinterFlags;
   curPos: number;
   pos: number;
   token: TokenSyntaxKind;

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -207,7 +207,7 @@ export interface LinterOptions {
 /**
  * The parser options.
  */
- export interface Options {
+export interface Options {
   next?: boolean;
   disableWebCompat?: boolean;
   impliedStrict?: boolean;
@@ -579,6 +579,18 @@ function parseCaseBlock(
     SyntaxKind.RightBrace,
     DiagnosticCode.The_parser_expected_to_find_a_to_match_the_token_here
   );
+
+  // linter; 'require switch default'
+  if (!hasDefaultCase && parser.linterFlags & LinterFlags.SwitchDefault) {
+    parser.onError(
+      DiagnosticSource.Parser,
+      DiagnosticKind.Error | DiagnosticKind.Linter,
+      diagnosticMap[DiagnosticCode.A_default_clause_is_required],
+      pos,
+      parser.curPos
+    );
+  }
+
   return createCaseBlock(clauses, pos, parser.curPos);
 }
 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -185,6 +185,7 @@ import {
   addBlockName,
   ScopeFlags,
   lookupBreakTarget,
+  LinterFlags,
   consumeKeywordAndCheckForEscapeSequence
 } from './common';
 
@@ -197,15 +198,29 @@ export interface Options {
   impliedStrict?: boolean;
   allowTypes?: boolean;
   autoFix?: boolean;
+  linter?: any;
+}
+
+export interface LinterOptions {
+  switchDefault?: boolean;
+  noCommaOperator?: boolean;
+  noCatchAssign?: boolean;
+  noDebugger?: boolean;
+  noEmptyBlocks?: boolean;
+  noNestedTernary?: boolean;
+  noSparseArray?: boolean;
+  noEmpty?: boolean;
+  noExtraParens?: boolean;
 }
 
 /**
  * Create a new parser instance.
  */
-export function create(source: string, pos: number, onError: OnError): ParserState {
+export function create(source: string, pos: number, linterFlags: LinterFlags, onError: OnError): ParserState {
   return {
     source,
     nodeFlags: NodeFlags.None,
+    linterFlags,
     curPos: 0,
     pos,
     end: source.length,
@@ -229,12 +244,25 @@ export function parse(
   onError: OnError,
   options?: Options
 ): RootNode {
+  let linter = LinterFlags.None;
   if (options != null) {
     if (options.next) context |= Context.OptionsNext;
     if (options.impliedStrict) context |= Context.Strict;
     if (options.allowTypes) context |= Context.OptionsAllowTypes;
     if (options.autoFix) context |= Context.OptionsAutoFix;
     if (options.disableWebCompat) context |= Context.OptionsDisableWebCompat;
+    if (options.linter) {
+      let linterOptions: LinterOptions = options.linter;
+      if (linterOptions.switchDefault) linter |= LinterFlags.SwitchDefault;
+      if (linterOptions.noCommaOperator) linter |= LinterFlags.NoCommaOperator;
+      if (linterOptions.noCatchAssign) linter |= LinterFlags.NoCatchAssign;
+      if (linterOptions.noDebugger) linter |= LinterFlags.NoDebugger;
+      if (linterOptions.noEmptyBlocks) linter |= LinterFlags.NoEmptyBlocks;
+      if (linterOptions.noNestedTernary) linter |= LinterFlags.NoNestedTernary;
+      if (linterOptions.noSparseArray) linter |= LinterFlags.NoSparseArray;
+      if (linterOptions.noEmpty) linter |= LinterFlags.NoEmpty;
+      if (linterOptions.noExtraParens) linter |= LinterFlags.noExtraParens;
+    }
   }
   let pos = 0;
 
@@ -260,7 +288,7 @@ export function parse(
     }
   }
 
-  const parser = create(source, pos, onError);
+  const parser = create(source, pos, linter, onError);
 
   // Prime the scanner
   nextToken(parser, context | Context.AllowRegExp);

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -190,17 +190,8 @@ import {
 } from './common';
 
 /**
- * The parser options.
+ * The linter options.
  */
-export interface Options {
-  next?: boolean;
-  disableWebCompat?: boolean;
-  impliedStrict?: boolean;
-  allowTypes?: boolean;
-  autoFix?: boolean;
-  linter?: any;
-}
-
 export interface LinterOptions {
   switchDefault?: boolean;
   noCommaOperator?: boolean;
@@ -211,6 +202,18 @@ export interface LinterOptions {
   noSparseArray?: boolean;
   noEmpty?: boolean;
   noExtraParens?: boolean;
+}
+
+/**
+ * The parser options.
+ */
+ export interface Options {
+  next?: boolean;
+  disableWebCompat?: boolean;
+  impliedStrict?: boolean;
+  allowTypes?: boolean;
+  autoFix?: boolean;
+  linterOptions?: LinterOptions;
 }
 
 /**
@@ -251,8 +254,8 @@ export function parse(
     if (options.allowTypes) context |= Context.OptionsAllowTypes;
     if (options.autoFix) context |= Context.OptionsAutoFix;
     if (options.disableWebCompat) context |= Context.OptionsDisableWebCompat;
-    if (options.linter) {
-      let linterOptions: LinterOptions = options.linter;
+    if (options.linterOptions) {
+      let linterOptions: LinterOptions = options.linterOptions;
       if (linterOptions.switchDefault) linter |= LinterFlags.SwitchDefault;
       if (linterOptions.noCommaOperator) linter |= LinterFlags.NoCommaOperator;
       if (linterOptions.noCatchAssign) linter |= LinterFlags.NoCatchAssign;

--- a/test/__snapshot__/parser/statements/switch/linter-require-default.md
+++ b/test/__snapshot__/parser/statements/switch/linter-require-default.md
@@ -1,0 +1,73 @@
+# Kataw parser test case
+
+## Options
+
+`````js
+{ linterOptions: { switchDefault: true}, disableWebCompat: true, module: true }
+`````
+
+## Input
+
+`````js
+switch (x) {}
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 160,
+            "switchKeyword": {
+                "kind": 37757024,
+                "flags": 80,
+                "start": 0,
+                "end": 6
+            },
+            "expression": {
+                "kind": 134299649,
+                "text": "x",
+                "rawText": "x",
+                "flags": 96,
+                "start": 8,
+                "end": 9
+            },
+            "caseBlock": {
+                "kind": 152,
+                "clauses": [],
+                "flags": 16,
+                "start": 10,
+                "end": 13
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 13
+        }
+    ],
+    "isModule": true,
+    "source": "switch (x) {}",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 13
+}
+```
+
+### Printed
+
+```javascript
+
+```
+
+### Diagnostics
+
+```javascript
+✖ A 'default' clause is required - start: 10, end: 13
+
+```
+


### PR DESCRIPTION
This adds a linter to Kataw. By default an `autoFix` option can be enabled and it will try to fix as much errors as possible.

Additional rules can be set like this:

```ts
{
linterOptions: {
    SwitchDefault: true // require switch default
  }
}
```
The diagnostics has been updated with a `Linter` bitwise mask so it's possible to use a different color for this in an reporter.

The question is what kind of rules should we allow? We have only 28 slots available - 28 rules we can add.

Example on current API approach:

```ts
kataw.parseScript('switch(x) {}', { linterOptions: { switchDefault: true} }, function() {});

// A 'default' clause is required
```
