### PR TITLE
chore: add ignore-comments

### DIFF
--- a/src/parser/scanner/scanner.ts
+++ b/src/parser/scanner/scanner.ts
@@ -320,6 +320,34 @@ export function scan(parser: ParserState, context: Context): SyntaxKind {
           let pos = parser.pos;
           while (pos < parser.end && !isLineTerminator(cp)) {
             cp = source.charCodeAt(++pos);
+            // kataw-ignore
+            if (
+              cp === Char.LowerK &&
+              source.charCodeAt(pos + 1) === Char.LowerA &&
+              source.charCodeAt(pos + 11) === Char.LowerE &&
+              source.charCodeAt(pos + 10) === Char.LowerR &&
+              source.charCodeAt(pos + 9) === Char.LowerO &&
+              source.charCodeAt(pos + 8) === Char.LowerN &&
+              source.charCodeAt(pos + 7) === Char.LowerG &&
+              source.charCodeAt(pos + 5) === Char.Hyphen &&
+              source.charCodeAt(pos + 6) === Char.LowerI &&
+              source.charCodeAt(pos + 2) === Char.LowerT &&
+              source.charCodeAt(pos + 3) === Char.LowerA &&
+              source.charCodeAt(pos + 4) === Char.LowerW
+            ) {
+              parser.nodeFlags |= NodeFlags.IgnoreNextLine;
+              // kataw-ignore-block
+              if (
+                source.charCodeAt(pos + 17) === Char.LowerK &&
+                source.charCodeAt(pos + 16) === Char.LowerC &&
+                source.charCodeAt(pos + 15) === Char.LowerO &&
+                source.charCodeAt(pos + 14) === Char.LowerL &&
+                source.charCodeAt(pos + 12) === Char.Hyphen &&
+                source.charCodeAt(pos + 13) === Char.LowerB
+              ) {
+                parser.nodeFlags |= NodeFlags.IgnoreNextLine | NodeFlags.IgnoreBlock;
+              }
+            }
           }
           parser.pos = pos;
           break;

--- a/src/parser/scanner/scanner.ts
+++ b/src/parser/scanner/scanner.ts
@@ -322,7 +322,8 @@ export function scan(parser: ParserState, context: Context): SyntaxKind {
             cp = source.charCodeAt(++pos);
             // kataw-ignore
             if (
-              (cp === Char.LowerK && source.charCodeAt(pos + 1) === Char.LowerA) &&
+              cp === Char.LowerK &&
+              source.charCodeAt(pos + 1) === Char.LowerA &&
               source.charCodeAt(pos + 11) === Char.LowerE &&
               source.charCodeAt(pos + 10) === Char.LowerR &&
               source.charCodeAt(pos + 9) === Char.LowerO &&

--- a/src/parser/scanner/scanner.ts
+++ b/src/parser/scanner/scanner.ts
@@ -322,8 +322,7 @@ export function scan(parser: ParserState, context: Context): SyntaxKind {
             cp = source.charCodeAt(++pos);
             // kataw-ignore
             if (
-              cp === Char.LowerK &&
-              source.charCodeAt(pos + 1) === Char.LowerA &&
+              (cp === Char.LowerK && source.charCodeAt(pos + 1) === Char.LowerA) &&
               source.charCodeAt(pos + 11) === Char.LowerE &&
               source.charCodeAt(pos + 10) === Char.LowerR &&
               source.charCodeAt(pos + 9) === Char.LowerO &&
@@ -345,7 +344,7 @@ export function scan(parser: ParserState, context: Context): SyntaxKind {
                 source.charCodeAt(pos + 12) === Char.Hyphen &&
                 source.charCodeAt(pos + 13) === Char.LowerB
               ) {
-                parser.nodeFlags |= NodeFlags.IgnoreNextLine | NodeFlags.IgnoreBlock;
+                parser.nodeFlags |= NodeFlags.IgnoreBlock;
               }
             }
           }

--- a/test/__snapshot__/parser/declarations/function/async-generator-errors/gen/declaration/yield_x003d_1_.md
+++ b/test/__snapshot__/parser/declarations/function/async-generator-errors/gen/declaration/yield_x003d_1_.md
@@ -132,14 +132,12 @@ async function * gen() {yield = 1;}
 
 ```javascript
 
-async function * gen() {
-   yield = 1;
-}
 ```
 
 ### Diagnostics
 
 ```javascript
-✔ No errors
+✖ The left-hand side of an assignment expression must be a variable or a property access - start: 29, end: 31
+
 ```
 

--- a/test/__snapshot__/parser/declarations/function/async-generator-errors/gen/expression/yield_x003d_1_.md
+++ b/test/__snapshot__/parser/declarations/function/async-generator-errors/gen/expression/yield_x003d_1_.md
@@ -159,14 +159,12 @@
 
 ```javascript
 
-({ * async gen() {
-     yield = 1;
-  } });
 ```
 
 ### Diagnostics
 
 ```javascript
-✔ No errors
+✖ The left-hand side of an assignment expression must be a variable or a property access - start: 24, end: 26
+
 ```
 

--- a/test/__snapshot__/parser/declarations/function/func-with-yield-divide-in-body1.md
+++ b/test/__snapshot__/parser/declarations/function/func-with-yield-divide-in-body1.md
@@ -3,9 +3,15 @@
 ## Input
 
 `````js
-function *f() {
-  yield *= x;
-}
+function f1() { yield / 1 /g }
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
 `````
 
 ## Output
@@ -27,18 +33,13 @@ function *f() {
                 "start": 0,
                 "end": 8
             },
-            "generatorToken": {
-                "kind": 67143222,
-                "flags": 64,
-                "start": 8,
-                "end": 10
-            },
+            "generatorToken": null,
             "name": {
                 "kind": 134299649,
-                "text": "f",
-                "rawText": "f",
+                "text": "f1",
+                "rawText": "f1",
                 "flags": 96,
-                "start": 10,
+                "start": 8,
                 "end": 11
             },
             "formalParameters": {
@@ -58,34 +59,47 @@ function *f() {
                         {
                             "kind": 120,
                             "expression": {
-                                "kind": 125,
+                                "kind": 198,
                                 "left": {
-                                    "kind": 229,
-                                    "yieldKeyword": {
-                                        "kind": 8454253,
-                                        "flags": 65,
+                                    "kind": 198,
+                                    "left": {
+                                        "kind": 134299649,
+                                        "text": "yield",
+                                        "rawText": "yield",
+                                        "flags": 96,
                                         "start": 15,
+                                        "end": 21
+                                    },
+                                    "operatorToken": {
+                                        "kind": 35640,
+                                        "flags": 64,
+                                        "start": 21,
                                         "end": 23
                                     },
-                                    "delegate": false,
-                                    "asteriskToken": null,
-                                    "expression": null,
+                                    "right": {
+                                        "kind": 201392130,
+                                        "text": 1,
+                                        "rawText": "1",
+                                        "flags": 96,
+                                        "start": 23,
+                                        "end": 25
+                                    },
                                     "flags": 32,
                                     "start": 15,
-                                    "end": 23
+                                    "end": 25
                                 },
                                 "operatorToken": {
-                                    "kind": 4132,
+                                    "kind": 35640,
                                     "flags": 64,
-                                    "start": 23,
-                                    "end": 26
+                                    "start": 25,
+                                    "end": 27
                                 },
                                 "right": {
                                     "kind": 134299649,
-                                    "text": "x",
-                                    "rawText": "x",
+                                    "text": "g",
+                                    "rawText": "g",
                                     "flags": 96,
-                                    "start": 26,
+                                    "start": 27,
                                     "end": 28
                                 },
                                 "flags": 32,
@@ -94,30 +108,30 @@ function *f() {
                             },
                             "flags": 16,
                             "start": 15,
-                            "end": 29
+                            "end": 28
                         }
                     ],
-                    "flags": 33,
+                    "flags": 32,
                     "start": 15,
-                    "end": 29
+                    "end": 28
                 },
                 "flags": 32,
                 "start": 13,
-                "end": 31
+                "end": 30
             },
             "typeParameters": null,
             "returnType": null,
-            "flags": 272,
+            "flags": 16,
             "start": 0,
-            "end": 31
+            "end": 30
         }
     ],
     "isModule": false,
-    "source": "function *f() {\n  yield *= x;\n}",
+    "source": "function f1() { yield / 1 /g }",
     "fileName": "__root__",
     "flags": 0,
     "start": 0,
-    "end": 31
+    "end": 30
 }
 ```
 
@@ -125,12 +139,14 @@ function *f() {
 
 ```javascript
 
+function f1() {
+  yield / 1 / g;
+}
 ```
 
 ### Diagnostics
 
 ```javascript
-✖ The left-hand side of an assignment expression must be a variable or a property access - start: 23, end: 26
-
+✔ No errors
 ```
 

--- a/test/__snapshot__/parser/declarations/function/func-with-yield-divide-in-body2.md
+++ b/test/__snapshot__/parser/declarations/function/func-with-yield-divide-in-body2.md
@@ -3,9 +3,15 @@
 ## Input
 
 `````js
-function *f() {
-  yield *= x;
-}
+function f2() { yield /=2 /d }
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
 `````
 
 ## Output
@@ -27,18 +33,13 @@ function *f() {
                 "start": 0,
                 "end": 8
             },
-            "generatorToken": {
-                "kind": 67143222,
-                "flags": 64,
-                "start": 8,
-                "end": 10
-            },
+            "generatorToken": null,
             "name": {
                 "kind": 134299649,
-                "text": "f",
-                "rawText": "f",
+                "text": "f2",
+                "rawText": "f2",
                 "flags": 96,
-                "start": 10,
+                "start": 8,
                 "end": 11
             },
             "formalParameters": {
@@ -60,32 +61,45 @@ function *f() {
                             "expression": {
                                 "kind": 125,
                                 "left": {
-                                    "kind": 229,
-                                    "yieldKeyword": {
-                                        "kind": 8454253,
-                                        "flags": 65,
-                                        "start": 15,
-                                        "end": 23
-                                    },
-                                    "delegate": false,
-                                    "asteriskToken": null,
-                                    "expression": null,
-                                    "flags": 32,
+                                    "kind": 134299649,
+                                    "text": "yield",
+                                    "rawText": "yield",
+                                    "flags": 96,
                                     "start": 15,
-                                    "end": 23
+                                    "end": 21
                                 },
                                 "operatorToken": {
-                                    "kind": 4132,
+                                    "kind": 4133,
                                     "flags": 64,
-                                    "start": 23,
-                                    "end": 26
+                                    "start": 21,
+                                    "end": 24
                                 },
                                 "right": {
-                                    "kind": 134299649,
-                                    "text": "x",
-                                    "rawText": "x",
-                                    "flags": 96,
-                                    "start": 26,
+                                    "kind": 198,
+                                    "left": {
+                                        "kind": 201392130,
+                                        "text": 2,
+                                        "rawText": "2",
+                                        "flags": 96,
+                                        "start": 24,
+                                        "end": 25
+                                    },
+                                    "operatorToken": {
+                                        "kind": 35640,
+                                        "flags": 64,
+                                        "start": 25,
+                                        "end": 27
+                                    },
+                                    "right": {
+                                        "kind": 134299649,
+                                        "text": "d",
+                                        "rawText": "d",
+                                        "flags": 96,
+                                        "start": 27,
+                                        "end": 28
+                                    },
+                                    "flags": 32,
+                                    "start": 24,
                                     "end": 28
                                 },
                                 "flags": 32,
@@ -94,30 +108,30 @@ function *f() {
                             },
                             "flags": 16,
                             "start": 15,
-                            "end": 29
+                            "end": 28
                         }
                     ],
-                    "flags": 33,
+                    "flags": 32,
                     "start": 15,
-                    "end": 29
+                    "end": 28
                 },
                 "flags": 32,
                 "start": 13,
-                "end": 31
+                "end": 30
             },
             "typeParameters": null,
             "returnType": null,
-            "flags": 272,
+            "flags": 16,
             "start": 0,
-            "end": 31
+            "end": 30
         }
     ],
     "isModule": false,
-    "source": "function *f() {\n  yield *= x;\n}",
+    "source": "function f2() { yield /=2 /d }",
     "fileName": "__root__",
     "flags": 0,
     "start": 0,
-    "end": 31
+    "end": 30
 }
 ```
 
@@ -125,12 +139,14 @@ function *f() {
 
 ```javascript
 
+function f2() {
+  yield /= 2 / d;
+}
 ```
 
 ### Diagnostics
 
 ```javascript
-✖ The left-hand side of an assignment expression must be a variable or a property access - start: 23, end: 26
-
+✔ No errors
 ```
 

--- a/test/__snapshot__/parser/declarations/function/function-generator-escaped-yield.md
+++ b/test/__snapshot__/parser/declarations/function/function-generator-escaped-yield.md
@@ -129,12 +129,14 @@ function *foo() { (x = \u0079ield) }
 
 ```javascript
 
+function * foo() {
+  (x =  yield);
+}
 ```
 
 ### Diagnostics
 
 ```javascript
-✖ 'yield' keyword must not contain escaped characters - start: 22, end: 22
-
+✔ No errors
 ```
 

--- a/test/__snapshot__/parser/declarations/function/generator-conditional.md
+++ b/test/__snapshot__/parser/declarations/function/generator-conditional.md
@@ -3,9 +3,17 @@
 ## Input
 
 `````js
-function *f() {
-  yield *= x;
+function* fn() {
+  a ? yield : 2
 }
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
 `````
 
 ## Output
@@ -31,23 +39,23 @@ function *f() {
                 "kind": 67143222,
                 "flags": 64,
                 "start": 8,
-                "end": 10
+                "end": 9
             },
             "name": {
                 "kind": 134299649,
-                "text": "f",
-                "rawText": "f",
+                "text": "fn",
+                "rawText": "fn",
                 "flags": 96,
-                "start": 10,
-                "end": 11
+                "start": 9,
+                "end": 12
             },
             "formalParameters": {
                 "kind": 214,
                 "formalParameterList": [],
                 "trailingComma": false,
                 "flags": 32,
-                "start": 11,
-                "end": 13
+                "start": 12,
+                "end": 14
             },
             "contents": {
                 "kind": 216,
@@ -58,66 +66,80 @@ function *f() {
                         {
                             "kind": 120,
                             "expression": {
-                                "kind": 125,
-                                "left": {
+                                "kind": 197,
+                                "shortCircuit": {
+                                    "kind": 134299649,
+                                    "text": "a",
+                                    "rawText": "a",
+                                    "flags": 96,
+                                    "start": 16,
+                                    "end": 20
+                                },
+                                "questionToken": {
+                                    "kind": 134217750,
+                                    "flags": 64,
+                                    "start": 20,
+                                    "end": 22
+                                },
+                                "consequent": {
                                     "kind": 229,
                                     "yieldKeyword": {
                                         "kind": 8454253,
-                                        "flags": 65,
-                                        "start": 15,
-                                        "end": 23
+                                        "flags": 64,
+                                        "start": 22,
+                                        "end": 28
                                     },
                                     "delegate": false,
                                     "asteriskToken": null,
                                     "expression": null,
                                     "flags": 32,
-                                    "start": 15,
-                                    "end": 23
-                                },
-                                "operatorToken": {
-                                    "kind": 4132,
-                                    "flags": 64,
-                                    "start": 23,
-                                    "end": 26
-                                },
-                                "right": {
-                                    "kind": 134299649,
-                                    "text": "x",
-                                    "rawText": "x",
-                                    "flags": 96,
-                                    "start": 26,
+                                    "start": 22,
                                     "end": 28
                                 },
+                                "colonToken": {
+                                    "kind": 21,
+                                    "flags": 64,
+                                    "start": 28,
+                                    "end": 30
+                                },
+                                "alternate": {
+                                    "kind": 201392130,
+                                    "text": 2,
+                                    "rawText": "2",
+                                    "flags": 96,
+                                    "start": 30,
+                                    "end": 32
+                                },
                                 "flags": 32,
-                                "start": 15,
-                                "end": 28
+                                "start": 16,
+                                "end": 32
                             },
                             "flags": 16,
-                            "start": 15,
-                            "end": 29
+                            "start": 16,
+                            "end": 32
                         }
                     ],
                     "flags": 33,
-                    "start": 15,
-                    "end": 29
+                    "start": 16,
+                    "end": 32
                 },
                 "flags": 32,
-                "start": 13,
-                "end": 31
+                "start": 14,
+                "end": 34
             },
             "typeParameters": null,
             "returnType": null,
             "flags": 272,
             "start": 0,
-            "end": 31
+            "end": 34
         }
     ],
     "isModule": false,
-    "source": "function *f() {\n  yield *= x;\n}",
+    "source": "function* fn() {\n  a ? yield : 2\n}",
     "fileName": "__root__",
     "flags": 0,
     "start": 0,
-    "end": 31
+    "end": 34
 }
 ```
 
@@ -125,12 +147,14 @@ function *f() {
 
 ```javascript
 
+function * fn() {
+  a ?  yield : 2;
+}
 ```
 
 ### Diagnostics
 
 ```javascript
-✖ The left-hand side of an assignment expression must be a variable or a property access - start: 23, end: 26
-
+✔ No errors
 ```
 

--- a/test/__snapshot__/parser/declarations/function/invalid-geneator-star-bracket.md
+++ b/test/__snapshot__/parser/declarations/function/invalid-geneator-star-bracket.md
@@ -3,9 +3,9 @@
 ## Input
 
 `````js
-function *f() {
+function* fn() {
   yield
-  * 1;
+  * []
 }
 `````
 
@@ -32,23 +32,23 @@ function *f() {
                 "kind": 67143222,
                 "flags": 64,
                 "start": 8,
-                "end": 10
+                "end": 9
             },
             "name": {
                 "kind": 134299649,
-                "text": "f",
-                "rawText": "f",
+                "text": "fn",
+                "rawText": "fn",
                 "flags": 96,
-                "start": 10,
-                "end": 11
+                "start": 9,
+                "end": 12
             },
             "formalParameters": {
                 "kind": 214,
                 "formalParameterList": [],
                 "trailingComma": false,
                 "flags": 32,
-                "start": 11,
-                "end": 13
+                "start": 12,
+                "end": 14
             },
             "contents": {
                 "kind": 216,
@@ -63,54 +63,60 @@ function *f() {
                                 "yieldKeyword": {
                                     "kind": 8454253,
                                     "flags": 65,
-                                    "start": 15,
-                                    "end": 23
+                                    "start": 16,
+                                    "end": 24
                                 },
                                 "delegate": true,
                                 "asteriskToken": {
                                     "kind": 67143222,
                                     "flags": 65,
-                                    "start": 23,
-                                    "end": 27
+                                    "start": 24,
+                                    "end": 28
                                 },
                                 "expression": {
-                                    "kind": 201392130,
-                                    "text": 1,
-                                    "rawText": "1",
-                                    "flags": 96,
-                                    "start": 27,
-                                    "end": 29
+                                    "kind": 119,
+                                    "elementList": {
+                                        "kind": 270,
+                                        "elements": [],
+                                        "trailingComma": false,
+                                        "flags": 32,
+                                        "start": 30,
+                                        "end": 30
+                                    },
+                                    "flags": 32,
+                                    "start": 28,
+                                    "end": 31
                                 },
                                 "flags": 32,
-                                "start": 15,
-                                "end": 29
+                                "start": 16,
+                                "end": 31
                             },
                             "flags": 16,
-                            "start": 15,
-                            "end": 30
+                            "start": 16,
+                            "end": 31
                         }
                     ],
                     "flags": 33,
-                    "start": 15,
-                    "end": 30
+                    "start": 16,
+                    "end": 31
                 },
                 "flags": 32,
-                "start": 13,
-                "end": 32
+                "start": 14,
+                "end": 33
             },
             "typeParameters": null,
             "returnType": null,
             "flags": 272,
             "start": 0,
-            "end": 32
+            "end": 33
         }
     ],
     "isModule": false,
-    "source": "function *f() {\n  yield\n  * 1;\n}",
+    "source": "function* fn() {\n  yield\n  * []\n}",
     "fileName": "__root__",
     "flags": 0,
     "start": 0,
-    "end": 32
+    "end": 33
 }
 ```
 
@@ -123,7 +129,7 @@ function *f() {
 ### Diagnostics
 
 ```javascript
-✖ Expression expected - start: 27, end: 29
+✖ Expression expected - start: 28, end: 30
 
 ```
 

--- a/test/__snapshot__/parser/expressions/assignment/kataw-ignore1.md
+++ b/test/__snapshot__/parser/expressions/assignment/kataw-ignore1.md
@@ -1,0 +1,76 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+// kataw-ignore-block
+foo = bar;
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 125,
+                "left": {
+                    "kind": 134299649,
+                    "text": "foo",
+                    "rawText": "foo",
+                    "flags": 96,
+                    "start": 0,
+                    "end": 25
+                },
+                "operatorToken": {
+                    "kind": 4125,
+                    "flags": 64,
+                    "start": 25,
+                    "end": 27
+                },
+                "right": {
+                    "kind": 134299649,
+                    "text": "bar",
+                    "rawText": "bar",
+                    "flags": 96,
+                    "start": 27,
+                    "end": 31
+                },
+                "flags": 32,
+                "start": 0,
+                "end": 31
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 32
+        }
+    ],
+    "isModule": false,
+    "source": "// kataw-ignore-block\nfoo = bar;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 32
+}
+```
+
+### Printed
+
+```javascript
+// kataw-ignore-block
+
+foo = bar;
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/expressions/assignment/kataw-ignore2.md
+++ b/test/__snapshot__/parser/expressions/assignment/kataw-ignore2.md
@@ -1,0 +1,76 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+// kataw-ignore-block
+foo = bar;
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 125,
+                "left": {
+                    "kind": 134299649,
+                    "text": "foo",
+                    "rawText": "foo",
+                    "flags": 96,
+                    "start": 0,
+                    "end": 25
+                },
+                "operatorToken": {
+                    "kind": 4125,
+                    "flags": 64,
+                    "start": 25,
+                    "end": 27
+                },
+                "right": {
+                    "kind": 134299649,
+                    "text": "bar",
+                    "rawText": "bar",
+                    "flags": 96,
+                    "start": 27,
+                    "end": 31
+                },
+                "flags": 32,
+                "start": 0,
+                "end": 31
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 32
+        }
+    ],
+    "isModule": false,
+    "source": "// kataw-ignore-block\nfoo = bar;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 32
+}
+```
+
+### Printed
+
+```javascript
+// kataw-ignore-block
+
+foo = bar;
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/expressions/assignment/kataw-ignore2.md
+++ b/test/__snapshot__/parser/expressions/assignment/kataw-ignore2.md
@@ -3,7 +3,7 @@
 ## Input
 
 `````js
-// kataw-ignore-block
+// kataw-ignore
 foo = bar;
 `````
 
@@ -26,44 +26,44 @@ foo = bar;
                     "rawText": "foo",
                     "flags": 96,
                     "start": 0,
-                    "end": 25
+                    "end": 19
                 },
                 "operatorToken": {
                     "kind": 4125,
                     "flags": 64,
-                    "start": 25,
-                    "end": 27
+                    "start": 19,
+                    "end": 21
                 },
                 "right": {
                     "kind": 134299649,
                     "text": "bar",
                     "rawText": "bar",
                     "flags": 96,
-                    "start": 27,
-                    "end": 31
+                    "start": 21,
+                    "end": 25
                 },
                 "flags": 32,
                 "start": 0,
-                "end": 31
+                "end": 25
             },
             "flags": 16,
             "start": 0,
-            "end": 32
+            "end": 26
         }
     ],
     "isModule": false,
-    "source": "// kataw-ignore-block\nfoo = bar;",
+    "source": "// kataw-ignore\nfoo = bar;",
     "fileName": "__root__",
     "flags": 0,
     "start": 0,
-    "end": 32
+    "end": 26
 }
 ```
 
 ### Printed
 
 ```javascript
-// kataw-ignore-block
+// kataw-ignore
 
 foo = bar;
 ```

--- a/test/__snapshot__/parser/expressions/assignment/target-cover-yieldexpr.md
+++ b/test/__snapshot__/parser/expressions/assignment/target-cover-yieldexpr.md
@@ -131,14 +131,12 @@ function* g() {
 
 ```javascript
 
-function * g() {
-  ( yield) = 1;
-}
 ```
 
 ### Diagnostics
 
 ```javascript
-✔ No errors
+✖ The left-hand side of an assignment expression must be a variable or a property access - start: 25, end: 27
+
 ```
 

--- a/test/__snapshot__/parser/expressions/assignment/to_keyword/gen/assign_to_keyword_in_generator/yield.md
+++ b/test/__snapshot__/parser/expressions/assignment/to_keyword/gen/assign_to_keyword_in_generator/yield.md
@@ -128,14 +128,12 @@ function *f(){
 
 ```javascript
 
-function * f() {
-   yield = 1;
-}
 ```
 
 ### Diagnostics
 
 ```javascript
-✔ No errors
+✖ The left-hand side of an assignment expression must be a variable or a property access - start: 22, end: 24
+
 ```
 

--- a/test/__snapshot__/parser/expressions/assignment/to_keyword/gen/assign_to_paren-wrapped_keyword_in_generator_param_default/yield.md
+++ b/test/__snapshot__/parser/expressions/assignment/to_keyword/gen/assign_to_paren-wrapped_keyword_in_generator_param_default/yield.md
@@ -149,6 +149,7 @@ function *f(x = (yield) = f) {}
 
 ```javascript
 ✖ `yield` expression cannot be used in function parameters - start: 17, end: 22
+✖ The left-hand side of an assignment expression must be a variable or a property access - start: 23, end: 25
 
 ```
 

--- a/test/__snapshot__/parser/expressions/assignment/to_keyword/gen/assign_to_paren_wrapped_keyword_in_a_generator/yield.md
+++ b/test/__snapshot__/parser/expressions/assignment/to_keyword/gen/assign_to_paren_wrapped_keyword_in_a_generator/yield.md
@@ -134,14 +134,12 @@ function *f(){
 
 ```javascript
 
-function * f() {
-  ( yield) = 1;
-}
 ```
 
 ### Diagnostics
 
 ```javascript
-✔ No errors
+✖ The left-hand side of an assignment expression must be a variable or a property access - start: 24, end: 26
+
 ```
 

--- a/test/__snapshot__/parser/expressions/async-generator/errors.md
+++ b/test/__snapshot__/parser/expressions/async-generator/errors.md
@@ -7568,8 +7568,10 @@ async function * gen() {class C extends await { }}
 ✖ `yield` expression cannot be used in function parameters - start: 734, end: 739
 ✖ `await` expression cannot be used in function parameters - start: 792, end: 797
 ✖ `await` expression cannot be used in function parameters - start: 850, end: 855
+✖ The left-hand side of an assignment expression must be a variable or a property access - start: 892, end: 894
 ✖ Identifier expected - start: 928, end: 930
 ✖ The left-hand side of an assignment expression must be a variable or a property access - start: 928, end: 930
+✖ The left-hand side of an assignment expression must be a variable or a property access - start: 974, end: 976
 ✖ Identifier expected - start: 1020, end: 1022
 ✖ The left-hand side of an assignment expression must be a variable or a property access - start: 1020, end: 1022
 ✖ The operand of an increment or decrement operator must be a variable or a property access - start: 1058, end: 1059
@@ -7602,8 +7604,10 @@ async function * gen() {class C extends await { }}
 ✖ 'await' cannot be used as an identifier here - start: 2121, end: 2126
 ✖ 'yield' cannot be used as an identifier here - start: 2170, end: 2176
 ✖ 'await' cannot be used as an identifier here - start: 2223, end: 2229
+✖ The left-hand side must be a variable or a property access. - start: 2274, end: 2276
 ✖ Identifier expected - start: 2314, end: 2315
 ✖ The left-hand side must be a variable or a property access. - start: 2315, end: 2317
+✖ The left-hand side must be a variable or a property access. - start: 2350, end: 2362
 ✖ Identifier expected - start: 2408, end: 2409
 ✖ The left-hand side must be a variable or a property access. - start: 2399, end: 2411
 ✖ 'yield' cannot be used as an identifier here - start: 2509, end: 2514

--- a/test/__snapshot__/parser/expressions/await/async-await-errors/gen/stand_alone/functionx002a_gx0028x0029_x007b_var_f_x003d_asyncx0028yieldx0029_x003dx003e_1_x007d.md
+++ b/test/__snapshot__/parser/expressions/await/async-await-errors/gen/stand_alone/functionx002a_gx0028x0029_x007b_var_f_x003d_asyncx0028yieldx0029_x003dx003e_1_x007d.md
@@ -89,23 +89,44 @@ function* g() { var f = async(yield) => 1; }
                                                 "end": 39
                                             },
                                             "typeParameters": null,
-                                            "parameters": [
-                                                {
-                                                    "kind": 229,
-                                                    "yieldKeyword": {
-                                                        "kind": 8454253,
-                                                        "flags": 64,
-                                                        "start": 30,
-                                                        "end": 35
-                                                    },
-                                                    "delegate": false,
-                                                    "asteriskToken": null,
-                                                    "expression": null,
+                                            "parameters": {
+                                                "kind": 131,
+                                                "expression": {
+                                                    "kind": 134299649,
+                                                    "text": "async",
+                                                    "rawText": "async",
+                                                    "flags": 96,
+                                                    "start": 23,
+                                                    "end": 29
+                                                },
+                                                "argumentList": {
+                                                    "kind": 256,
+                                                    "elements": [
+                                                        {
+                                                            "kind": 229,
+                                                            "yieldKeyword": {
+                                                                "kind": 8454253,
+                                                                "flags": 64,
+                                                                "start": 30,
+                                                                "end": 35
+                                                            },
+                                                            "delegate": false,
+                                                            "asteriskToken": null,
+                                                            "expression": null,
+                                                            "flags": 32,
+                                                            "start": 30,
+                                                            "end": 35
+                                                        }
+                                                    ],
+                                                    "trailingComma": false,
                                                     "flags": 32,
-                                                    "start": 30,
-                                                    "end": 35
-                                                }
-                                            ],
+                                                    "start": 23,
+                                                    "end": 23
+                                                },
+                                                "flags": 268435488,
+                                                "start": 23,
+                                                "end": 36
+                                            },
                                             "asyncKeyword": {
                                                 "kind": 82031,
                                                 "flags": 64,
@@ -121,7 +142,7 @@ function* g() { var f = async(yield) => 1; }
                                                 "start": 39,
                                                 "end": 41
                                             },
-                                            "flags": 288,
+                                            "flags": 32,
                                             "start": 23,
                                             "end": 41
                                         },
@@ -168,7 +189,7 @@ function* g() { var f = async(yield) => 1; }
 ```javascript
 
 function * g() {
-  var f = async ( yield) =>  1;
+  var f = async async( yield) =>  1;
 }
 ```
 

--- a/test/__snapshot__/parser/expressions/await/async-await-errors/gen/with_strict_directive/functionx002a_gx0028x0029_x007b_var_f_x003d_asyncx0028yieldx0029_x003dx003e_1_x007d.md
+++ b/test/__snapshot__/parser/expressions/await/async-await-errors/gen/with_strict_directive/functionx002a_gx0028x0029_x007b_var_f_x003d_asyncx0028yieldx0029_x003dx003e_1_x007d.md
@@ -98,23 +98,44 @@
                                                 "end": 53
                                             },
                                             "typeParameters": null,
-                                            "parameters": [
-                                                {
-                                                    "kind": 229,
-                                                    "yieldKeyword": {
-                                                        "kind": 8454253,
-                                                        "flags": 64,
-                                                        "start": 44,
-                                                        "end": 49
-                                                    },
-                                                    "delegate": false,
-                                                    "asteriskToken": null,
-                                                    "expression": null,
+                                            "parameters": {
+                                                "kind": 131,
+                                                "expression": {
+                                                    "kind": 134299649,
+                                                    "text": "async",
+                                                    "rawText": "async",
+                                                    "flags": 96,
+                                                    "start": 37,
+                                                    "end": 43
+                                                },
+                                                "argumentList": {
+                                                    "kind": 256,
+                                                    "elements": [
+                                                        {
+                                                            "kind": 229,
+                                                            "yieldKeyword": {
+                                                                "kind": 8454253,
+                                                                "flags": 64,
+                                                                "start": 44,
+                                                                "end": 49
+                                                            },
+                                                            "delegate": false,
+                                                            "asteriskToken": null,
+                                                            "expression": null,
+                                                            "flags": 32,
+                                                            "start": 44,
+                                                            "end": 49
+                                                        }
+                                                    ],
+                                                    "trailingComma": false,
                                                     "flags": 32,
-                                                    "start": 44,
-                                                    "end": 49
-                                                }
-                                            ],
+                                                    "start": 37,
+                                                    "end": 37
+                                                },
+                                                "flags": 268435488,
+                                                "start": 37,
+                                                "end": 50
+                                            },
                                             "asyncKeyword": {
                                                 "kind": 82031,
                                                 "flags": 64,
@@ -130,7 +151,7 @@
                                                 "start": 53,
                                                 "end": 55
                                             },
-                                            "flags": 288,
+                                            "flags": 32,
                                             "start": 37,
                                             "end": 55
                                         },
@@ -177,7 +198,7 @@
 ```javascript
 
 function * g() {
-  var f = async ( yield) =>  1;
+  var f = async async( yield) =>  1;
 }
 ```
 

--- a/test/__snapshot__/parser/expressions/yield/asi_before_star.md
+++ b/test/__snapshot__/parser/expressions/yield/asi_before_star.md
@@ -131,7 +131,7 @@ function *f() {
 ### Diagnostics
 
 ```javascript
-✖ Expression expected - start: 27, end: 33
+✖ Expression expected - start: 33, end: 35
 
 ```
 

--- a/test/__snapshot__/parser/expressions/yield/yield_newline_star.md
+++ b/test/__snapshot__/parser/expressions/yield/yield_newline_star.md
@@ -122,7 +122,7 @@ function *f() {
 ### Diagnostics
 
 ```javascript
-✖ Expression expected - start: 23, end: 27
+✖ Expression expected - start: 27, end: 29
 ✖ Identifier expected - start: 27, end: 29
 
 ```

--- a/test/__snapshot__/parser/miscellaneous/escaped-keywords/gen/stand-alone/x0028function_x002agenx0028x0029_x007b_yix005cu0065ldx003a_x007dx0029.md
+++ b/test/__snapshot__/parser/miscellaneous/escaped-keywords/gen/stand-alone/x0028function_x002agenx0028x0029_x007b_yix005cu0065ldx003a_x007dx0029.md
@@ -134,7 +134,6 @@
 ### Diagnostics
 
 ```javascript
-✖ 'yield' keyword must not contain escaped characters - start: 18, end: 18
 ✖ Unicode escapes at the start of labels should not allow keywords - start: 18, end: 30
 
 ```

--- a/test/__snapshot__/parser/miscellaneous/escaped-keywords/gen/stand-alone/x0028functionx002ax0028x0029_x007b_yx005cu0069eld_1_x007dx0029x0028x0029.md
+++ b/test/__snapshot__/parser/miscellaneous/escaped-keywords/gen/stand-alone/x0028functionx002ax0028x0029_x007b_yx005cu0069eld_1_x007dx0029x0028x0029.md
@@ -131,12 +131,14 @@
 
 ```javascript
 
+(function * () {
+    yield 1;
+  })();
 ```
 
 ### Diagnostics
 
 ```javascript
-✖ 'yield' keyword must not contain escaped characters - start: 14, end: 14
-
+✔ No errors
 ```
 

--- a/test/__snapshot__/parser/miscellaneous/escaped-keywords/gen/strict_mode/x0028function_x002agenx0028x0029_x007b_yix005cu0065ldx003a_x007dx0029.md
+++ b/test/__snapshot__/parser/miscellaneous/escaped-keywords/gen/strict_mode/x0028function_x002agenx0028x0029_x007b_yix005cu0065ldx003a_x007dx0029.md
@@ -134,7 +134,6 @@
 ### Diagnostics
 
 ```javascript
-✖ 'yield' keyword must not contain escaped characters - start: 18, end: 18
 ✖ Unicode escapes at the start of labels should not allow keywords - start: 18, end: 30
 
 ```

--- a/test/__snapshot__/parser/miscellaneous/escaped-keywords/gen/strict_mode/x0028functionx002ax0028x0029_x007b_yx005cu0069eld_1_x007dx0029x0028x0029.md
+++ b/test/__snapshot__/parser/miscellaneous/escaped-keywords/gen/strict_mode/x0028functionx002ax0028x0029_x007b_yx005cu0069eld_1_x007dx0029x0028x0029.md
@@ -131,12 +131,14 @@
 
 ```javascript
 
+(function * () {
+    yield 1;
+  })();
 ```
 
 ### Diagnostics
 
 ```javascript
-✖ 'yield' keyword must not contain escaped characters - start: 14, end: 14
-
+✔ No errors
 ```
 

--- a/test/__snapshot__/parser/statements/for-await/yield_arg_with_60in60_lhs.md
+++ b/test/__snapshot__/parser/statements/for-await/yield_arg_with_60in60_lhs.md
@@ -228,6 +228,7 @@ async function f(){
 ```javascript
 ✖ A 'for-await-of' statement is only allowed within an async function or async generator. - start: 50, end: 52
 ✖ Cannot use the 'yield' keyword on the left-hand side of a 'for...in' statement in a generator context - start: 52, end: 59
+✖ The left-hand side of a 'for...in' statement must be a variable or a property access. - start: 62, end: 64
 ✖ Expected a ')' to match the '(' token here - start: 64, end: 67
 ✖ Expected a `;` - start: 67, end: 69
 ✖ Expected a `;` - start: 69, end: 70

--- a/test/__snapshot__/parser/statements/for-in/invalid-cases.md
+++ b/test/__snapshot__/parser/statements/for-in/invalid-cases.md
@@ -7024,6 +7024,7 @@ for ({}.bar = x in obj);
 ✖ Identifier expected - start: 1052, end: 1055
 ✖ Expected a `;` - start: 1059, end: 1060
 ✖ Cannot use the 'yield' keyword on the left-hand side of a 'for...in' statement in a generator context - start: 1085, end: 1092
+✖ The left-hand side of a 'for...in' statement must be a variable or a property access. - start: 1095, end: 1097
 ✖ The left-hand side of an assignment expression may not be an optional property access - start: 1139, end: 1142
 ✖ The left-hand side of an assignment expression must be a variable or a property access - start: 1140, end: 1142
 ✖ The left-hand side of a 'for...in' statement must be a variable or a property access. - start: 1149, end: 1151

--- a/test/__snapshot__/parser/statements/for-in/yield_arg_lhs.md
+++ b/test/__snapshot__/parser/statements/for-in/yield_arg_lhs.md
@@ -161,6 +161,7 @@ function *f(){   for (yield x in y);   }
 
 ```javascript
 ✖ Cannot use the 'yield' keyword on the left-hand side of a 'for...in' statement in a generator context - start: 22, end: 29
+✖ The left-hand side of a 'for...in' statement must be a variable or a property access. - start: 32, end: 34
 
 ```
 

--- a/test/__snapshot__/parser/statements/for-in/yield_arg_with_60in60_lhs.md
+++ b/test/__snapshot__/parser/statements/for-in/yield_arg_with_60in60_lhs.md
@@ -181,6 +181,7 @@ function *f(){   for (yield x in y in z);   }
 
 ```javascript
 ✖ Cannot use the 'yield' keyword on the left-hand side of a 'for...in' statement in a generator context - start: 22, end: 29
+✖ The left-hand side of a 'for...in' statement must be a variable or a property access. - start: 32, end: 34
 
 ```
 


### PR DESCRIPTION
This PR adds support for  `// kataw-ignore` and  `// kataw-ignore-block`. A `NodeFlag` has been added and will allow us to ignore the next line or an entire block.

This is an faster approach than comment extraction + slice and string comparison as done in ESLint

If one of this comments are added it will ignore linting / print format for a single line or an entire block.