### PR TITLE
chore:  improve arrow function type parsing

### DIFF
--- a/src/ast/syntax-node.ts
+++ b/src/ast/syntax-node.ts
@@ -313,7 +313,7 @@ export enum SyntaxKind {
   StringKeyword = 134234347,
   StringLiteral = 201392131,
   StringType = 134217967,
-  Subtract = 100915,
+  Subtract = 134318643,
   SubtractAssign = 4131,
   Super = 225,
   SuperKeyword = 4259935,

--- a/src/diagnostic/diagnostic-code.ts
+++ b/src/diagnostic/diagnostic-code.ts
@@ -238,7 +238,8 @@ export const enum DiagnosticCode {
   _MethodDefinition_expected = 243,
   A_class_field_cannot_have_a_field_named_constructor = 244,
   Class_fields_may_not_have_a_static_property_named_prototype = 245,
-  Cannot_use_the_yield_keyword_on_the_left_hand_side_of_conditional_expression_in_a_generator_context = 246
+  Cannot_use_the_yield_keyword_on_the_left_hand_side_of_conditional_expression_in_a_generator_context = 246,
+  An_optional_parameter_cannot_be_used_without_an_in_an_arrow_function_type_parameter_list = 247
 }
 
 export const diagnosticMap: { [key: number]: string } = {
@@ -481,5 +482,6 @@ export const diagnosticMap: { [key: number]: string } = {
   [243]: '`MethodDefinition` expected',
   [244]: "A class field cannot have a field named 'constructor'",
   [245]: "Class fields may not have a static property named 'prototype'",
-  [246]: "Cannot use the 'yield' keyword on the left-hand side of conditional expression in a generator context"
+  [246]: "Cannot use the 'yield' keyword on the left-hand side of conditional expression in a generator context",
+  [247]: "An optional parameter cannot be used without an ':' in an arrow function type parameter list"
 };

--- a/src/diagnostic/diagnosticMessages.json
+++ b/src/diagnostic/diagnosticMessages.json
@@ -235,8 +235,6 @@
   "`MethodDefinition` expected": 243,
   "A class field cannot have a field named 'constructor'": 244,
   "Class fields may not have a static property named 'prototype'": 245,
-  "Cannot use the 'yield' keyword on the left-hand side of conditional expression in a generator context": 246
+  "Cannot use the 'yield' keyword on the left-hand side of conditional expression in a generator context": 246,
+  "An optional parameter cannot be used without an ':' in an arrow function type parameter list": 247
 }
-
-
-

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -7398,7 +7398,9 @@ function parseParenthesizedType(parser: ParserState, context: Context): any {
         parser.onError(
           DiagnosticSource.Parser,
           DiagnosticKind.Error,
-          diagnosticMap[DiagnosticCode.Type_expected],
+          diagnosticMap[
+            DiagnosticCode.An_optional_parameter_cannot_be_used_without_an_in_an_arrow_function_type_parameter_list
+          ],
           parser.curPos,
           parser.pos
         );
@@ -7529,9 +7531,9 @@ function parseParenthesizedType(parser: ParserState, context: Context): any {
       );
     } else {
       type = parseIdentifier(parser, context, 0b00000000110000000100000000000000, DiagnosticCode.Type_expected);
-      // - `(x?) => T;`
-      // - `(x?: y) => T;`
-      // - `(x: y) => T;`
+      // - `((x?) => T);`
+      // - `((x?: y) => T);`
+      // - `((x: y) => T);`
       if (
         (parser.token as SyntaxKind) === SyntaxKind.QuestionMark ||
         (parser.token as SyntaxKind) === SyntaxKind.Colon
@@ -7542,7 +7544,9 @@ function parseParenthesizedType(parser: ParserState, context: Context): any {
           parser.onError(
             DiagnosticSource.Parser,
             DiagnosticKind.Error,
-            diagnosticMap[DiagnosticCode.Type_expected],
+            diagnosticMap[
+              DiagnosticCode.An_optional_parameter_cannot_be_used_without_an_in_an_arrow_function_type_parameter_list
+            ],
             parser.curPos,
             parser.pos
           );

--- a/test/__snapshot__/parser/declarations/async-function/valid-cases.md
+++ b/test/__snapshot__/parser/declarations/async-function/valid-cases.md
@@ -31,7 +31,7 @@ new async function() { await 0 }.x
                 "left": {
                     "kind": 126,
                     "operandToken": {
-                        "kind": 100915,
+                        "kind": 134318643,
                         "flags": 64,
                         "start": 0,
                         "end": 1
@@ -119,7 +119,7 @@ new async function() { await 0 }.x
                     "end": 33
                 },
                 "operatorToken": {
-                    "kind": 100915,
+                    "kind": 134318643,
                     "flags": 65,
                     "start": 33,
                     "end": 35
@@ -216,7 +216,7 @@ new async function() { await 0 }.x
                     "end": 65
                 },
                 "operatorToken": {
-                    "kind": 100915,
+                    "kind": 134318643,
                     "flags": 64,
                     "start": 65,
                     "end": 67
@@ -320,7 +320,7 @@ new async function() { await 0 }.x
                     "end": 102
                 },
                 "operatorToken": {
-                    "kind": 100915,
+                    "kind": 134318643,
                     "flags": 64,
                     "start": 102,
                     "end": 104

--- a/test/__snapshot__/parser/declarations/function/logical.md
+++ b/test/__snapshot__/parser/declarations/function/logical.md
@@ -11298,7 +11298,7 @@ function logical19b(x: { y: string, z: boolean }): boolean {
                                         "end": 8267
                                     },
                                     "operatorToken": {
-                                        "kind": 100915,
+                                        "kind": 134318643,
                                         "flags": 64,
                                         "start": 8267,
                                         "end": 8269
@@ -11332,7 +11332,7 @@ function logical19b(x: { y: string, z: boolean }): boolean {
                                         "end": 8276
                                     },
                                     "operatorToken": {
-                                        "kind": 100915,
+                                        "kind": 134318643,
                                         "flags": 64,
                                         "start": 8276,
                                         "end": 8278
@@ -11564,7 +11564,7 @@ function logical19b(x: { y: string, z: boolean }): boolean {
                                         "end": 8413
                                     },
                                     "operatorToken": {
-                                        "kind": 100915,
+                                        "kind": 134318643,
                                         "flags": 64,
                                         "start": 8413,
                                         "end": 8415
@@ -11612,7 +11612,7 @@ function logical19b(x: { y: string, z: boolean }): boolean {
                                         "end": 8424
                                     },
                                     "operatorToken": {
-                                        "kind": 100915,
+                                        "kind": 134318643,
                                         "flags": 64,
                                         "start": 8424,
                                         "end": 8426

--- a/test/__snapshot__/parser/declarations/let/tuples.md
+++ b/test/__snapshot__/parser/declarations/let/tuples.md
@@ -176,7 +176,7 @@ let tests = [
                                                             "expression": {
                                                                 "kind": 126,
                                                                 "operandToken": {
-                                                                    "kind": 100915,
+                                                                    "kind": 134318643,
                                                                     "flags": 64,
                                                                     "start": 80,
                                                                     "end": 81

--- a/test/__snapshot__/parser/declarations/type/annotate_escaped_generics-alias.md
+++ b/test/__snapshot__/parser/declarations/type/annotate_escaped_generics-alias.md
@@ -53,67 +53,107 @@ type Tr = <Return>(() => Pr<Return>) => Return;
                     "end": 18
                 },
                 "returnType": {
-                    "kind": 260,
-                    "type": {
-                        "kind": 261,
-                        "arrowToken": {
-                            "kind": 10,
-                            "flags": 64,
-                            "start": 21,
-                            "end": 24
-                        },
-                        "parameters": [],
-                        "returnType": {
-                            "kind": 144,
-                            "id": {
-                                "kind": 134299649,
-                                "text": "Pr",
-                                "rawText": "Pr",
-                                "flags": 96,
-                                "start": 24,
-                                "end": 27
-                            },
-                            "typeParameters": {
-                                "kind": 266,
-                                "parameters": [
-                                    {
-                                        "kind": 267,
-                                        "type": {
-                                            "kind": 144,
-                                            "id": {
-                                                "kind": 134299649,
-                                                "text": "Return",
-                                                "rawText": "Return",
-                                                "flags": 96,
+                    "kind": 261,
+                    "arrowToken": {
+                        "kind": 10,
+                        "flags": 64,
+                        "start": 36,
+                        "end": 39
+                    },
+                    "parameters": {
+                        "kind": 279,
+                        "parameters": [
+                            {
+                                "kind": 261,
+                                "arrowToken": {
+                                    "kind": 10,
+                                    "flags": 64,
+                                    "start": 21,
+                                    "end": 24
+                                },
+                                "parameters": {
+                                    "kind": 279,
+                                    "parameters": [
+                                        []
+                                    ],
+                                    "trailingComma": false,
+                                    "flags": 32,
+                                    "start": 18,
+                                    "end": 24
+                                },
+                                "returnType": {
+                                    "kind": 144,
+                                    "id": {
+                                        "kind": 134299649,
+                                        "text": "Pr",
+                                        "rawText": "Pr",
+                                        "flags": 96,
+                                        "start": 24,
+                                        "end": 27
+                                    },
+                                    "typeParameters": {
+                                        "kind": 266,
+                                        "parameters": [
+                                            {
+                                                "kind": 267,
+                                                "type": {
+                                                    "kind": 144,
+                                                    "id": {
+                                                        "kind": 134299649,
+                                                        "text": "Return",
+                                                        "rawText": "Return",
+                                                        "flags": 96,
+                                                        "start": 28,
+                                                        "end": 34
+                                                    },
+                                                    "typeParameters": null,
+                                                    "flags": 0,
+                                                    "start": 28,
+                                                    "end": 34
+                                                },
+                                                "flags": 0,
                                                 "start": 28,
                                                 "end": 34
-                                            },
-                                            "typeParameters": null,
-                                            "flags": 0,
-                                            "start": 28,
-                                            "end": 34
-                                        },
+                                            }
+                                        ],
                                         "flags": 0,
-                                        "start": 28,
-                                        "end": 34
-                                    }
-                                ],
+                                        "start": 27,
+                                        "end": 35
+                                    },
+                                    "flags": 0,
+                                    "start": 24,
+                                    "end": 35
+                                },
+                                "typeParameters": null,
                                 "flags": 0,
-                                "start": 27,
+                                "start": 18,
                                 "end": 35
-                            },
-                            "flags": 0,
-                            "start": 24,
-                            "end": 35
+                            }
+                        ],
+                        "trailingComma": false,
+                        "flags": 32,
+                        "start": 18,
+                        "end": 39
+                    },
+                    "returnType": {
+                        "kind": 144,
+                        "id": {
+                            "kind": 134299649,
+                            "text": "Return",
+                            "rawText": "Return",
+                            "flags": 96,
+                            "start": 39,
+                            "end": 46
                         },
                         "typeParameters": null,
                         "flags": 0,
-                        "start": 18,
-                        "end": 35
+                        "start": 39,
+                        "end": 46
                     },
+                    "typeParameters": null,
                     "flags": 0,
                     "start": 18,
-                    "end": 36
+                    "end": 46
                 },
                 "typeParameters": {
                     "kind": 265,
@@ -141,24 +181,10 @@ type Tr = <Return>(() => Pr<Return>) => Return;
                 },
                 "flags": 0,
                 "start": 9,
-                "end": 36
-            },
-            "flags": 16,
-            "start": 0,
-            "end": 36
-        },
-        {
-            "kind": 120,
-            "expression": {
-                "kind": 134299649,
-                "text": "Return",
-                "rawText": "Return",
-                "flags": 96,
-                "start": 39,
                 "end": 46
             },
             "flags": 16,
-            "start": 39,
+            "start": 0,
             "end": 47
         }
     ],
@@ -175,12 +201,12 @@ type Tr = <Return>(() => Pr<Return>) => Return;
 
 ```javascript
 
+
 ```
 
 ### Diagnostics
 
 ```javascript
-✖ Expected a `;` - start: 36, end: 39
-
+✔ No errors
 ```
 

--- a/test/__snapshot__/parser/declarations/type/anonymous-function-types12.md
+++ b/test/__snapshot__/parser/declarations/type/anonymous-function-types12.md
@@ -79,14 +79,23 @@ var f = (x): ((number) => 123) => 123;
                                             "start": 22,
                                             "end": 25
                                         },
-                                        "parameters": [
-                                            {
-                                                "kind": 134234345,
-                                                "flags": 64,
-                                                "start": 15,
-                                                "end": 21
-                                            }
-                                        ],
+                                        "parameters": {
+                                            "kind": 279,
+                                            "parameters": [
+                                                {
+                                                    "kind": 134299649,
+                                                    "text": "number",
+                                                    "rawText": "number",
+                                                    "flags": 96,
+                                                    "start": 15,
+                                                    "end": 21
+                                                }
+                                            ],
+                                            "trailingComma": false,
+                                            "flags": 32,
+                                            "start": 12,
+                                            "end": 25
+                                        },
                                         "returnType": {
                                             "kind": 134217968,
                                             "value": 123,

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type11.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type11.md
@@ -49,15 +49,22 @@ type a = ("string") => T;
                     "start": 19,
                     "end": 22
                 },
-                "parameters": [
-                    {
-                        "kind": 134217967,
-                        "value": "string",
-                        "flags": 0,
-                        "start": 10,
-                        "end": 18
-                    }
-                ],
+                "parameters": {
+                    "kind": 279,
+                    "parameters": [
+                        {
+                            "kind": 134217967,
+                            "value": "string",
+                            "flags": 0,
+                            "start": 10,
+                            "end": 18
+                        }
+                    ],
+                    "trailingComma": false,
+                    "flags": 32,
+                    "start": 8,
+                    "end": 22
+                },
                 "returnType": {
                     "kind": 144,
                     "id": {

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type14.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type14.md
@@ -49,81 +49,88 @@ type a = (?c & a | b) => T;
                     "start": 21,
                     "end": 24
                 },
-                "parameters": [
-                    {
-                        "kind": 137,
-                        "types": [
-                            {
-                                "kind": 138,
-                                "types": [
-                                    {
-                                        "kind": 134217970,
-                                        "nullableToken": {
-                                            "kind": 134217750,
-                                            "flags": 64,
-                                            "start": 10,
-                                            "end": 11
-                                        },
-                                        "type": {
-                                            "kind": 144,
-                                            "id": {
-                                                "kind": 134299649,
-                                                "text": "c",
-                                                "rawText": "c",
-                                                "flags": 96,
+                "parameters": {
+                    "kind": 279,
+                    "parameters": [
+                        {
+                            "kind": 137,
+                            "types": [
+                                {
+                                    "kind": 138,
+                                    "types": [
+                                        {
+                                            "kind": 134217970,
+                                            "nullableToken": {
+                                                "kind": 134217750,
+                                                "flags": 64,
+                                                "start": 10,
+                                                "end": 11
+                                            },
+                                            "type": {
+                                                "kind": 144,
+                                                "id": {
+                                                    "kind": 134299649,
+                                                    "text": "c",
+                                                    "rawText": "c",
+                                                    "flags": 96,
+                                                    "start": 11,
+                                                    "end": 12
+                                                },
+                                                "typeParameters": null,
+                                                "flags": 0,
                                                 "start": 11,
                                                 "end": 12
                                             },
-                                            "typeParameters": null,
                                             "flags": 0,
-                                            "start": 11,
+                                            "start": 10,
                                             "end": 12
                                         },
-                                        "flags": 0,
-                                        "start": 10,
-                                        "end": 12
-                                    },
-                                    {
-                                        "kind": 144,
-                                        "id": {
-                                            "kind": 134299649,
-                                            "text": "a",
-                                            "rawText": "a",
-                                            "flags": 96,
+                                        {
+                                            "kind": 144,
+                                            "id": {
+                                                "kind": 134299649,
+                                                "text": "a",
+                                                "rawText": "a",
+                                                "flags": 96,
+                                                "start": 14,
+                                                "end": 16
+                                            },
+                                            "typeParameters": null,
+                                            "flags": 0,
                                             "start": 14,
                                             "end": 16
-                                        },
-                                        "typeParameters": null,
-                                        "flags": 0,
-                                        "start": 14,
-                                        "end": 16
-                                    }
-                                ],
-                                "flags": 0,
-                                "start": 12,
-                                "end": 16
-                            },
-                            {
-                                "kind": 144,
-                                "id": {
-                                    "kind": 134299649,
-                                    "text": "b",
-                                    "rawText": "b",
-                                    "flags": 96,
+                                        }
+                                    ],
+                                    "flags": 0,
+                                    "start": 12,
+                                    "end": 16
+                                },
+                                {
+                                    "kind": 144,
+                                    "id": {
+                                        "kind": 134299649,
+                                        "text": "b",
+                                        "rawText": "b",
+                                        "flags": 96,
+                                        "start": 18,
+                                        "end": 20
+                                    },
+                                    "typeParameters": null,
+                                    "flags": 0,
                                     "start": 18,
                                     "end": 20
-                                },
-                                "typeParameters": null,
-                                "flags": 0,
-                                "start": 18,
-                                "end": 20
-                            }
-                        ],
-                        "flags": 0,
-                        "start": 16,
-                        "end": 20
-                    }
-                ],
+                                }
+                            ],
+                            "flags": 0,
+                            "start": 16,
+                            "end": 20
+                        }
+                    ],
+                    "trailingComma": false,
+                    "flags": 32,
+                    "start": 8,
+                    "end": 24
+                },
                 "returnType": {
                     "kind": 144,
                     "id": {

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type15.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type15.md
@@ -49,102 +49,109 @@ type a = (?bj[c] & a | b) => T;
                     "start": 25,
                     "end": 28
                 },
-                "parameters": [
-                    {
-                        "kind": 137,
-                        "types": [
-                            {
-                                "kind": 138,
-                                "types": [
-                                    {
-                                        "kind": 134217970,
-                                        "nullableToken": {
-                                            "kind": 134217750,
-                                            "flags": 64,
-                                            "start": 10,
-                                            "end": 11
-                                        },
-                                        "type": {
-                                            "kind": 268,
-                                            "objectType": {
-                                                "kind": 144,
-                                                "id": {
-                                                    "kind": 134299649,
-                                                    "text": "bj",
-                                                    "rawText": "bj",
-                                                    "flags": 96,
+                "parameters": {
+                    "kind": 279,
+                    "parameters": [
+                        {
+                            "kind": 137,
+                            "types": [
+                                {
+                                    "kind": 138,
+                                    "types": [
+                                        {
+                                            "kind": 134217970,
+                                            "nullableToken": {
+                                                "kind": 134217750,
+                                                "flags": 64,
+                                                "start": 10,
+                                                "end": 11
+                                            },
+                                            "type": {
+                                                "kind": 268,
+                                                "objectType": {
+                                                    "kind": 144,
+                                                    "id": {
+                                                        "kind": 134299649,
+                                                        "text": "bj",
+                                                        "rawText": "bj",
+                                                        "flags": 96,
+                                                        "start": 11,
+                                                        "end": 13
+                                                    },
+                                                    "typeParameters": null,
+                                                    "flags": 0,
                                                     "start": 11,
                                                     "end": 13
                                                 },
-                                                "typeParameters": null,
-                                                "flags": 0,
-                                                "start": 11,
-                                                "end": 13
-                                            },
-                                            "indexType": {
-                                                "kind": 144,
-                                                "id": {
-                                                    "kind": 134299649,
-                                                    "text": "c",
-                                                    "rawText": "c",
-                                                    "flags": 96,
+                                                "indexType": {
+                                                    "kind": 144,
+                                                    "id": {
+                                                        "kind": 134299649,
+                                                        "text": "c",
+                                                        "rawText": "c",
+                                                        "flags": 96,
+                                                        "start": 14,
+                                                        "end": 15
+                                                    },
+                                                    "typeParameters": null,
+                                                    "flags": 0,
                                                     "start": 14,
                                                     "end": 15
                                                 },
-                                                "typeParameters": null,
                                                 "flags": 0,
                                                 "start": 14,
-                                                "end": 15
+                                                "end": 18
                                             },
                                             "flags": 0,
-                                            "start": 14,
-                                            "end": 18
+                                            "start": 10,
+                                            "end": 16
                                         },
-                                        "flags": 0,
-                                        "start": 10,
-                                        "end": 16
-                                    },
-                                    {
-                                        "kind": 144,
-                                        "id": {
-                                            "kind": 134299649,
-                                            "text": "a",
-                                            "rawText": "a",
-                                            "flags": 96,
+                                        {
+                                            "kind": 144,
+                                            "id": {
+                                                "kind": 134299649,
+                                                "text": "a",
+                                                "rawText": "a",
+                                                "flags": 96,
+                                                "start": 18,
+                                                "end": 20
+                                            },
+                                            "typeParameters": null,
+                                            "flags": 0,
                                             "start": 18,
                                             "end": 20
-                                        },
-                                        "typeParameters": null,
-                                        "flags": 0,
-                                        "start": 18,
-                                        "end": 20
-                                    }
-                                ],
-                                "flags": 0,
-                                "start": 16,
-                                "end": 20
-                            },
-                            {
-                                "kind": 144,
-                                "id": {
-                                    "kind": 134299649,
-                                    "text": "b",
-                                    "rawText": "b",
-                                    "flags": 96,
+                                        }
+                                    ],
+                                    "flags": 0,
+                                    "start": 16,
+                                    "end": 20
+                                },
+                                {
+                                    "kind": 144,
+                                    "id": {
+                                        "kind": 134299649,
+                                        "text": "b",
+                                        "rawText": "b",
+                                        "flags": 96,
+                                        "start": 22,
+                                        "end": 24
+                                    },
+                                    "typeParameters": null,
+                                    "flags": 0,
                                     "start": 22,
                                     "end": 24
-                                },
-                                "typeParameters": null,
-                                "flags": 0,
-                                "start": 22,
-                                "end": 24
-                            }
-                        ],
-                        "flags": 0,
-                        "start": 20,
-                        "end": 24
-                    }
-                ],
+                                }
+                            ],
+                            "flags": 0,
+                            "start": 20,
+                            "end": 24
+                        }
+                    ],
+                    "trailingComma": false,
+                    "flags": 32,
+                    "start": 8,
+                    "end": 28
+                },
                 "returnType": {
                     "kind": 144,
                     "id": {

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type19.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type19.md
@@ -3,7 +3,7 @@
 ## Input
 
 `````js
-type a = (1) => T;
+type a = (1[]) => T;
 `````
 
 ## Options
@@ -46,24 +46,30 @@ type a = (1) => T;
                 "arrowToken": {
                     "kind": 10,
                     "flags": 64,
-                    "start": 12,
-                    "end": 15
+                    "start": 14,
+                    "end": 17
                 },
                 "parameters": {
                     "kind": 279,
                     "parameters": [
                         {
-                            "kind": 134217968,
-                            "value": 1,
+                            "kind": 136,
+                            "type": {
+                                "kind": 134217968,
+                                "value": 1,
+                                "flags": 0,
+                                "start": 10,
+                                "end": 11
+                            },
                             "flags": 0,
-                            "start": 10,
-                            "end": 11
+                            "start": 12,
+                            "end": 13
                         }
                     ],
                     "trailingComma": false,
                     "flags": 32,
                     "start": 8,
-                    "end": 15
+                    "end": 17
                 },
                 "returnType": {
                     "kind": 144,
@@ -72,30 +78,30 @@ type a = (1) => T;
                         "text": "T",
                         "rawText": "T",
                         "flags": 96,
-                        "start": 15,
-                        "end": 17
+                        "start": 17,
+                        "end": 19
                     },
                     "typeParameters": null,
                     "flags": 0,
-                    "start": 15,
-                    "end": 17
+                    "start": 17,
+                    "end": 19
                 },
                 "typeParameters": null,
                 "flags": 0,
                 "start": 8,
-                "end": 17
+                "end": 19
             },
             "flags": 16,
             "start": 0,
-            "end": 18
+            "end": 20
         }
     ],
     "isModule": false,
-    "source": "type a = (1) => T;",
+    "source": "type a = (1[]) => T;",
     "fileName": "__root__",
     "flags": 0,
     "start": 0,
-    "end": 18
+    "end": 20
 }
 ```
 

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type20.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type20.md
@@ -3,7 +3,7 @@
 ## Input
 
 `````js
-type a = (1) => T;
+type a = (1 | 1[]) => T;
 `````
 
 ## Options
@@ -46,24 +46,45 @@ type a = (1) => T;
                 "arrowToken": {
                     "kind": 10,
                     "flags": 64,
-                    "start": 12,
-                    "end": 15
+                    "start": 18,
+                    "end": 21
                 },
                 "parameters": {
                     "kind": 279,
                     "parameters": [
                         {
-                            "kind": 134217968,
-                            "value": 1,
+                            "kind": 137,
+                            "types": [
+                                {
+                                    "kind": 134217968,
+                                    "value": 1,
+                                    "flags": 0,
+                                    "start": 10,
+                                    "end": 11
+                                },
+                                {
+                                    "kind": 136,
+                                    "type": {
+                                        "kind": 134217968,
+                                        "value": 1,
+                                        "flags": 0,
+                                        "start": 13,
+                                        "end": 15
+                                    },
+                                    "flags": 0,
+                                    "start": 16,
+                                    "end": 17
+                                }
+                            ],
                             "flags": 0,
-                            "start": 10,
-                            "end": 11
+                            "start": 11,
+                            "end": 17
                         }
                     ],
                     "trailingComma": false,
                     "flags": 32,
                     "start": 8,
-                    "end": 15
+                    "end": 21
                 },
                 "returnType": {
                     "kind": 144,
@@ -72,30 +93,30 @@ type a = (1) => T;
                         "text": "T",
                         "rawText": "T",
                         "flags": 96,
-                        "start": 15,
-                        "end": 17
+                        "start": 21,
+                        "end": 23
                     },
                     "typeParameters": null,
                     "flags": 0,
-                    "start": 15,
-                    "end": 17
+                    "start": 21,
+                    "end": 23
                 },
                 "typeParameters": null,
                 "flags": 0,
                 "start": 8,
-                "end": 17
+                "end": 23
             },
             "flags": 16,
             "start": 0,
-            "end": 18
+            "end": 24
         }
     ],
     "isModule": false,
-    "source": "type a = (1) => T;",
+    "source": "type a = (1 | 1[]) => T;",
     "fileName": "__root__",
     "flags": 0,
     "start": 0,
-    "end": 18
+    "end": 24
 }
 ```
 

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type21.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type21.md
@@ -3,7 +3,7 @@
 ## Input
 
 `````js
-type a = (1) => T;
+type a = ({}[x]) => T;
 `````
 
 ## Options
@@ -46,24 +46,45 @@ type a = (1) => T;
                 "arrowToken": {
                     "kind": 10,
                     "flags": 64,
-                    "start": 12,
-                    "end": 15
+                    "start": 16,
+                    "end": 19
                 },
                 "parameters": {
                     "kind": 279,
                     "parameters": [
                         {
-                            "kind": 134217968,
-                            "value": 1,
+                            "kind": 268,
+                            "objectType": {
+                                "kind": 134234353,
+                                "properties": [],
+                                "flags": 0,
+                                "start": 10,
+                                "end": 12
+                            },
+                            "indexType": {
+                                "kind": 144,
+                                "id": {
+                                    "kind": 134299649,
+                                    "text": "x",
+                                    "rawText": "x",
+                                    "flags": 96,
+                                    "start": 13,
+                                    "end": 14
+                                },
+                                "typeParameters": null,
+                                "flags": 0,
+                                "start": 13,
+                                "end": 14
+                            },
                             "flags": 0,
-                            "start": 10,
-                            "end": 11
+                            "start": 13,
+                            "end": 16
                         }
                     ],
                     "trailingComma": false,
                     "flags": 32,
                     "start": 8,
-                    "end": 15
+                    "end": 19
                 },
                 "returnType": {
                     "kind": 144,
@@ -72,30 +93,30 @@ type a = (1) => T;
                         "text": "T",
                         "rawText": "T",
                         "flags": 96,
-                        "start": 15,
-                        "end": 17
+                        "start": 19,
+                        "end": 21
                     },
                     "typeParameters": null,
                     "flags": 0,
-                    "start": 15,
-                    "end": 17
+                    "start": 19,
+                    "end": 21
                 },
                 "typeParameters": null,
                 "flags": 0,
                 "start": 8,
-                "end": 17
+                "end": 21
             },
             "flags": 16,
             "start": 0,
-            "end": 18
+            "end": 22
         }
     ],
     "isModule": false,
-    "source": "type a = (1) => T;",
+    "source": "type a = ({}[x]) => T;",
     "fileName": "__root__",
     "flags": 0,
     "start": 0,
-    "end": 18
+    "end": 22
 }
 ```
 

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type22.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type22.md
@@ -1,0 +1,176 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = ({key():string}[x]) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 261,
+                "arrowToken": {
+                    "kind": 10,
+                    "flags": 64,
+                    "start": 28,
+                    "end": 31
+                },
+                "parameters": {
+                    "kind": 279,
+                    "parameters": [
+                        {
+                            "kind": 268,
+                            "objectType": {
+                                "kind": 134234353,
+                                "properties": [
+                                    {
+                                        "kind": 193,
+                                        "protoKeyword": null,
+                                        "staticToken": null,
+                                        "getKeyword": null,
+                                        "setKeyword": null,
+                                        "key": {
+                                            "kind": 134299649,
+                                            "text": "key",
+                                            "rawText": "key",
+                                            "flags": 96,
+                                            "start": 11,
+                                            "end": 14
+                                        },
+                                        "optionalToken": null,
+                                        "value": {
+                                            "kind": 148,
+                                            "parameters": {
+                                                "kind": 208,
+                                                "parameters": [],
+                                                "trailingComma": false,
+                                                "flags": 32,
+                                                "start": 15,
+                                                "end": 15
+                                            },
+                                            "returnType": {
+                                                "kind": 134234347,
+                                                "flags": 64,
+                                                "start": 17,
+                                                "end": 23
+                                            },
+                                            "typeParameters": null,
+                                            "flags": 0,
+                                            "start": 14,
+                                            "end": 23
+                                        },
+                                        "flags": 0,
+                                        "start": 11,
+                                        "end": 23
+                                    }
+                                ],
+                                "flags": 0,
+                                "start": 10,
+                                "end": 24
+                            },
+                            "indexType": {
+                                "kind": 144,
+                                "id": {
+                                    "kind": 134299649,
+                                    "text": "x",
+                                    "rawText": "x",
+                                    "flags": 96,
+                                    "start": 25,
+                                    "end": 26
+                                },
+                                "typeParameters": null,
+                                "flags": 0,
+                                "start": 25,
+                                "end": 26
+                            },
+                            "flags": 0,
+                            "start": 25,
+                            "end": 28
+                        }
+                    ],
+                    "trailingComma": false,
+                    "flags": 32,
+                    "start": 8,
+                    "end": 31
+                },
+                "returnType": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 134299649,
+                        "text": "T",
+                        "rawText": "T",
+                        "flags": 96,
+                        "start": 31,
+                        "end": 33
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 31,
+                    "end": 33
+                },
+                "typeParameters": null,
+                "flags": 0,
+                "start": 8,
+                "end": 33
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 34
+        }
+    ],
+    "isModule": false,
+    "source": "type a = ({key():string}[x]) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 34
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type24.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type24.md
@@ -1,0 +1,155 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (1 | 1[symbol & string]) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 261,
+                "arrowToken": {
+                    "kind": 10,
+                    "flags": 64,
+                    "start": 33,
+                    "end": 36
+                },
+                "parameters": {
+                    "kind": 279,
+                    "parameters": [
+                        {
+                            "kind": 137,
+                            "types": [
+                                {
+                                    "kind": 134217968,
+                                    "value": 1,
+                                    "flags": 0,
+                                    "start": 10,
+                                    "end": 11
+                                },
+                                {
+                                    "kind": 268,
+                                    "objectType": {
+                                        "kind": 134217968,
+                                        "value": 1,
+                                        "flags": 0,
+                                        "start": 13,
+                                        "end": 15
+                                    },
+                                    "indexType": {
+                                        "kind": 138,
+                                        "types": [
+                                            {
+                                                "kind": 134234343,
+                                                "flags": 64,
+                                                "start": 16,
+                                                "end": 22
+                                            },
+                                            {
+                                                "kind": 134234347,
+                                                "flags": 64,
+                                                "start": 24,
+                                                "end": 31
+                                            }
+                                        ],
+                                        "flags": 0,
+                                        "start": 22,
+                                        "end": 31
+                                    },
+                                    "flags": 0,
+                                    "start": 16,
+                                    "end": 33
+                                }
+                            ],
+                            "flags": 0,
+                            "start": 11,
+                            "end": 32
+                        }
+                    ],
+                    "trailingComma": false,
+                    "flags": 32,
+                    "start": 8,
+                    "end": 36
+                },
+                "returnType": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 134299649,
+                        "text": "T",
+                        "rawText": "T",
+                        "flags": 96,
+                        "start": 36,
+                        "end": 38
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 36,
+                    "end": 38
+                },
+                "typeParameters": null,
+                "flags": 0,
+                "start": 8,
+                "end": 38
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 39
+        }
+    ],
+    "isModule": false,
+    "source": "type a = (1 | 1[symbol & string]) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 39
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type25.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type25.md
@@ -3,7 +3,7 @@
 ## Input
 
 `````js
-type a = (1) => T;
+type a = (()=> T) => T;
 `````
 
 ## Options
@@ -46,24 +46,55 @@ type a = (1) => T;
                 "arrowToken": {
                     "kind": 10,
                     "flags": 64,
-                    "start": 12,
-                    "end": 15
+                    "start": 17,
+                    "end": 20
                 },
                 "parameters": {
                     "kind": 279,
                     "parameters": [
                         {
-                            "kind": 134217968,
-                            "value": 1,
+                            "kind": 261,
+                            "arrowToken": {
+                                "kind": 10,
+                                "flags": 64,
+                                "start": 12,
+                                "end": 14
+                            },
+                            "parameters": {
+                                "kind": 279,
+                                "parameters": [
+                                    []
+                                ],
+                                "trailingComma": false,
+                                "flags": 32,
+                                "start": 8,
+                                "end": 14
+                            },
+                            "returnType": {
+                                "kind": 144,
+                                "id": {
+                                    "kind": 134299649,
+                                    "text": "T",
+                                    "rawText": "T",
+                                    "flags": 96,
+                                    "start": 14,
+                                    "end": 16
+                                },
+                                "typeParameters": null,
+                                "flags": 0,
+                                "start": 14,
+                                "end": 16
+                            },
+                            "typeParameters": null,
                             "flags": 0,
-                            "start": 10,
-                            "end": 11
+                            "start": 8,
+                            "end": 16
                         }
                     ],
                     "trailingComma": false,
                     "flags": 32,
                     "start": 8,
-                    "end": 15
+                    "end": 20
                 },
                 "returnType": {
                     "kind": 144,
@@ -72,30 +103,30 @@ type a = (1) => T;
                         "text": "T",
                         "rawText": "T",
                         "flags": 96,
-                        "start": 15,
-                        "end": 17
+                        "start": 20,
+                        "end": 22
                     },
                     "typeParameters": null,
                     "flags": 0,
-                    "start": 15,
-                    "end": 17
+                    "start": 20,
+                    "end": 22
                 },
                 "typeParameters": null,
                 "flags": 0,
                 "start": 8,
-                "end": 17
+                "end": 22
             },
             "flags": 16,
             "start": 0,
-            "end": 18
+            "end": 23
         }
     ],
     "isModule": false,
-    "source": "type a = (1) => T;",
+    "source": "type a = (()=> T) => T;",
     "fileName": "__root__",
     "flags": 0,
     "start": 0,
-    "end": 18
+    "end": 23
 }
 ```
 

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type26.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type26.md
@@ -1,0 +1,177 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = ((x?:string)=> T) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 260,
+                "type": {
+                    "kind": 261,
+                    "arrowToken": {
+                        "kind": 10,
+                        "flags": 64,
+                        "start": 26,
+                        "end": 29
+                    },
+                    "parameters": {
+                        "kind": 279,
+                        "parameters": [
+                            {
+                                "kind": 261,
+                                "arrowToken": {
+                                    "kind": 10,
+                                    "flags": 64,
+                                    "start": 21,
+                                    "end": 23
+                                },
+                                "parameters": {
+                                    "kind": 279,
+                                    "parameters": [
+                                        {
+                                            "kind": 149,
+                                            "ellipsisToken": null,
+                                            "name": {
+                                                "kind": 134299649,
+                                                "text": "x",
+                                                "rawText": "x",
+                                                "flags": 96,
+                                                "start": 11,
+                                                "end": 12
+                                            },
+                                            "optionalToken": {
+                                                "kind": 134217750,
+                                                "flags": 64,
+                                                "start": 12,
+                                                "end": 13
+                                            },
+                                            "types": {
+                                                "kind": 134234347,
+                                                "flags": 64,
+                                                "start": 14,
+                                                "end": 20
+                                            },
+                                            "flags": 0,
+                                            "start": 8,
+                                            "end": 20
+                                        }
+                                    ],
+                                    "trailingComma": false,
+                                    "flags": 32,
+                                    "start": 8,
+                                    "end": 20
+                                },
+                                "returnType": {
+                                    "kind": 144,
+                                    "id": {
+                                        "kind": 134299649,
+                                        "text": "T",
+                                        "rawText": "T",
+                                        "flags": 96,
+                                        "start": 23,
+                                        "end": 25
+                                    },
+                                    "typeParameters": null,
+                                    "flags": 0,
+                                    "start": 23,
+                                    "end": 25
+                                },
+                                "typeParameters": null,
+                                "flags": 0,
+                                "start": 8,
+                                "end": 25
+                            }
+                        ],
+                        "trailingComma": false,
+                        "flags": 32,
+                        "start": 8,
+                        "end": 29
+                    },
+                    "returnType": {
+                        "kind": 144,
+                        "id": {
+                            "kind": 134299649,
+                            "text": "T",
+                            "rawText": "T",
+                            "flags": 96,
+                            "start": 29,
+                            "end": 31
+                        },
+                        "typeParameters": null,
+                        "flags": 0,
+                        "start": 29,
+                        "end": 31
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 8,
+                    "end": 31
+                },
+                "flags": 0,
+                "start": 8,
+                "end": 31
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 32
+        }
+    ],
+    "isModule": false,
+    "source": "type a = ((x?:string)=> T) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 32
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type27.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type27.md
@@ -1,0 +1,250 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = ((x?:string, (x?:string)=> T)=> T) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 260,
+                "type": {
+                    "kind": 261,
+                    "arrowToken": {
+                        "kind": 10,
+                        "flags": 64,
+                        "start": 43,
+                        "end": 46
+                    },
+                    "parameters": {
+                        "kind": 279,
+                        "parameters": [
+                            {
+                                "kind": 261,
+                                "arrowToken": {
+                                    "kind": 10,
+                                    "flags": 64,
+                                    "start": 38,
+                                    "end": 40
+                                },
+                                "parameters": {
+                                    "kind": 279,
+                                    "parameters": [
+                                        {
+                                            "kind": 149,
+                                            "ellipsisToken": null,
+                                            "name": {
+                                                "kind": 134299649,
+                                                "text": "x",
+                                                "rawText": "x",
+                                                "flags": 96,
+                                                "start": 11,
+                                                "end": 12
+                                            },
+                                            "optionalToken": {
+                                                "kind": 134217750,
+                                                "flags": 64,
+                                                "start": 12,
+                                                "end": 13
+                                            },
+                                            "types": {
+                                                "kind": 134234347,
+                                                "flags": 64,
+                                                "start": 14,
+                                                "end": 20
+                                            },
+                                            "flags": 0,
+                                            "start": 8,
+                                            "end": 20
+                                        },
+                                        {
+                                            "kind": 149,
+                                            "ellipsisToken": null,
+                                            "name": null,
+                                            "optionalToken": null,
+                                            "types": {
+                                                "kind": 261,
+                                                "arrowToken": {
+                                                    "kind": 10,
+                                                    "flags": 64,
+                                                    "start": 33,
+                                                    "end": 35
+                                                },
+                                                "parameters": {
+                                                    "kind": 279,
+                                                    "parameters": [
+                                                        {
+                                                            "kind": 149,
+                                                            "ellipsisToken": null,
+                                                            "name": {
+                                                                "kind": 134299649,
+                                                                "text": "x",
+                                                                "rawText": "x",
+                                                                "flags": 96,
+                                                                "start": 23,
+                                                                "end": 24
+                                                            },
+                                                            "optionalToken": {
+                                                                "kind": 134217750,
+                                                                "flags": 64,
+                                                                "start": 24,
+                                                                "end": 25
+                                                            },
+                                                            "types": {
+                                                                "kind": 134234347,
+                                                                "flags": 64,
+                                                                "start": 26,
+                                                                "end": 32
+                                                            },
+                                                            "flags": 0,
+                                                            "start": 21,
+                                                            "end": 32
+                                                        }
+                                                    ],
+                                                    "trailingComma": false,
+                                                    "flags": 32,
+                                                    "start": 21,
+                                                    "end": 32
+                                                },
+                                                "returnType": {
+                                                    "kind": 144,
+                                                    "id": {
+                                                        "kind": 134299649,
+                                                        "text": "T",
+                                                        "rawText": "T",
+                                                        "flags": 96,
+                                                        "start": 35,
+                                                        "end": 37
+                                                    },
+                                                    "typeParameters": null,
+                                                    "flags": 0,
+                                                    "start": 35,
+                                                    "end": 37
+                                                },
+                                                "typeParameters": null,
+                                                "flags": 0,
+                                                "start": 21,
+                                                "end": 37
+                                            },
+                                            "flags": 0,
+                                            "start": 21,
+                                            "end": 37
+                                        }
+                                    ],
+                                    "trailingComma": false,
+                                    "flags": 32,
+                                    "start": 8,
+                                    "end": 37
+                                },
+                                "returnType": {
+                                    "kind": 144,
+                                    "id": {
+                                        "kind": 134299649,
+                                        "text": "T",
+                                        "rawText": "T",
+                                        "flags": 96,
+                                        "start": 40,
+                                        "end": 42
+                                    },
+                                    "typeParameters": null,
+                                    "flags": 0,
+                                    "start": 40,
+                                    "end": 42
+                                },
+                                "typeParameters": null,
+                                "flags": 0,
+                                "start": 8,
+                                "end": 42
+                            }
+                        ],
+                        "trailingComma": false,
+                        "flags": 32,
+                        "start": 8,
+                        "end": 46
+                    },
+                    "returnType": {
+                        "kind": 144,
+                        "id": {
+                            "kind": 134299649,
+                            "text": "T",
+                            "rawText": "T",
+                            "flags": 96,
+                            "start": 46,
+                            "end": 48
+                        },
+                        "typeParameters": null,
+                        "flags": 0,
+                        "start": 46,
+                        "end": 48
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 8,
+                    "end": 48
+                },
+                "flags": 0,
+                "start": 8,
+                "end": 48
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 49
+        }
+    ],
+    "isModule": false,
+    "source": "type a = ((x?:string, (x?:string)=> T)=> T) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 49
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type28.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type28.md
@@ -1,0 +1,249 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = ((x?:string | (x?:string)=> T)=> T) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 260,
+                "type": {
+                    "kind": 261,
+                    "arrowToken": {
+                        "kind": 10,
+                        "flags": 64,
+                        "start": 44,
+                        "end": 47
+                    },
+                    "parameters": {
+                        "kind": 279,
+                        "parameters": [
+                            {
+                                "kind": 261,
+                                "arrowToken": {
+                                    "kind": 10,
+                                    "flags": 64,
+                                    "start": 39,
+                                    "end": 41
+                                },
+                                "parameters": {
+                                    "kind": 279,
+                                    "parameters": [
+                                        {
+                                            "kind": 149,
+                                            "ellipsisToken": null,
+                                            "name": {
+                                                "kind": 134299649,
+                                                "text": "x",
+                                                "rawText": "x",
+                                                "flags": 96,
+                                                "start": 11,
+                                                "end": 12
+                                            },
+                                            "optionalToken": {
+                                                "kind": 134217750,
+                                                "flags": 64,
+                                                "start": 12,
+                                                "end": 13
+                                            },
+                                            "types": {
+                                                "kind": 137,
+                                                "types": [
+                                                    {
+                                                        "kind": 134234347,
+                                                        "flags": 64,
+                                                        "start": 14,
+                                                        "end": 20
+                                                    },
+                                                    {
+                                                        "kind": 261,
+                                                        "arrowToken": {
+                                                            "kind": 10,
+                                                            "flags": 64,
+                                                            "start": 34,
+                                                            "end": 36
+                                                        },
+                                                        "parameters": {
+                                                            "kind": 279,
+                                                            "parameters": [
+                                                                {
+                                                                    "kind": 149,
+                                                                    "ellipsisToken": null,
+                                                                    "name": {
+                                                                        "kind": 134299649,
+                                                                        "text": "x",
+                                                                        "rawText": "x",
+                                                                        "flags": 96,
+                                                                        "start": 24,
+                                                                        "end": 25
+                                                                    },
+                                                                    "optionalToken": {
+                                                                        "kind": 134217750,
+                                                                        "flags": 64,
+                                                                        "start": 25,
+                                                                        "end": 26
+                                                                    },
+                                                                    "types": {
+                                                                        "kind": 134234347,
+                                                                        "flags": 64,
+                                                                        "start": 27,
+                                                                        "end": 33
+                                                                    },
+                                                                    "flags": 0,
+                                                                    "start": 22,
+                                                                    "end": 33
+                                                                }
+                                                            ],
+                                                            "trailingComma": false,
+                                                            "flags": 32,
+                                                            "start": 22,
+                                                            "end": 33
+                                                        },
+                                                        "returnType": {
+                                                            "kind": 144,
+                                                            "id": {
+                                                                "kind": 134299649,
+                                                                "text": "T",
+                                                                "rawText": "T",
+                                                                "flags": 96,
+                                                                "start": 36,
+                                                                "end": 38
+                                                            },
+                                                            "typeParameters": null,
+                                                            "flags": 0,
+                                                            "start": 36,
+                                                            "end": 38
+                                                        },
+                                                        "typeParameters": null,
+                                                        "flags": 0,
+                                                        "start": 22,
+                                                        "end": 38
+                                                    }
+                                                ],
+                                                "flags": 0,
+                                                "start": 20,
+                                                "end": 38
+                                            },
+                                            "flags": 0,
+                                            "start": 8,
+                                            "end": 38
+                                        }
+                                    ],
+                                    "trailingComma": false,
+                                    "flags": 32,
+                                    "start": 8,
+                                    "end": 38
+                                },
+                                "returnType": {
+                                    "kind": 144,
+                                    "id": {
+                                        "kind": 134299649,
+                                        "text": "T",
+                                        "rawText": "T",
+                                        "flags": 96,
+                                        "start": 41,
+                                        "end": 43
+                                    },
+                                    "typeParameters": null,
+                                    "flags": 0,
+                                    "start": 41,
+                                    "end": 43
+                                },
+                                "typeParameters": null,
+                                "flags": 0,
+                                "start": 8,
+                                "end": 43
+                            }
+                        ],
+                        "trailingComma": false,
+                        "flags": 32,
+                        "start": 8,
+                        "end": 47
+                    },
+                    "returnType": {
+                        "kind": 144,
+                        "id": {
+                            "kind": 134299649,
+                            "text": "T",
+                            "rawText": "T",
+                            "flags": 96,
+                            "start": 47,
+                            "end": 49
+                        },
+                        "typeParameters": null,
+                        "flags": 0,
+                        "start": 47,
+                        "end": 49
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 8,
+                    "end": 49
+                },
+                "flags": 0,
+                "start": 8,
+                "end": 49
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 50
+        }
+    ],
+    "isModule": false,
+    "source": "type a = ((x?:string | (x?:string)=> T)=> T) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 50
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type29.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type29.md
@@ -1,0 +1,259 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = ((q | y, x?:string | (x?:string)=> T)=> T) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 137,
+                "types": [
+                    {
+                        "kind": 260,
+                        "type": {
+                            "kind": 134299649,
+                            "text": "q",
+                            "rawText": "q",
+                            "flags": 96,
+                            "start": 11,
+                            "end": 12
+                        },
+                        "flags": 0,
+                        "start": 8,
+                        "end": 12
+                    },
+                    {
+                        "kind": 144,
+                        "id": {
+                            "kind": 134299649,
+                            "text": "y",
+                            "rawText": "y",
+                            "flags": 96,
+                            "start": 14,
+                            "end": 16
+                        },
+                        "typeParameters": null,
+                        "flags": 0,
+                        "start": 14,
+                        "end": 16
+                    }
+                ],
+                "flags": 0,
+                "start": 12,
+                "end": 16
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 16
+        },
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 197,
+                "shortCircuit": {
+                    "kind": 134299649,
+                    "text": "x",
+                    "rawText": "x",
+                    "flags": 96,
+                    "start": 17,
+                    "end": 19
+                },
+                "questionToken": {
+                    "kind": 134217750,
+                    "flags": 64,
+                    "start": 19,
+                    "end": 20
+                },
+                "consequent": {
+                    "kind": 16637,
+                    "text": "",
+                    "flags": 64,
+                    "start": 20,
+                    "end": 20
+                },
+                "colonToken": {
+                    "kind": 21,
+                    "flags": 64,
+                    "start": 20,
+                    "end": 21
+                },
+                "alternate": {
+                    "kind": 198,
+                    "left": {
+                        "kind": 134299649,
+                        "text": "string",
+                        "rawText": "string",
+                        "flags": 96,
+                        "start": 21,
+                        "end": 27
+                    },
+                    "operatorToken": {
+                        "kind": 134251592,
+                        "flags": 64,
+                        "start": 27,
+                        "end": 29
+                    },
+                    "right": {
+                        "kind": 271,
+                        "arrowToken": {
+                            "kind": 10,
+                            "flags": 64,
+                            "start": 41,
+                            "end": 43
+                        },
+                        "typeParameters": null,
+                        "parameters": [
+                            {
+                                "kind": 281,
+                                "ellipsisToken": null,
+                                "left": {
+                                    "kind": 134299649,
+                                    "text": "x",
+                                    "rawText": "x",
+                                    "flags": 96,
+                                    "start": 31,
+                                    "end": 32
+                                },
+                                "optionalToken": {
+                                    "kind": 134217750,
+                                    "flags": 64,
+                                    "start": 32,
+                                    "end": 33
+                                },
+                                "type": {
+                                    "kind": 139,
+                                    "type": {
+                                        "kind": 134234347,
+                                        "flags": 64,
+                                        "start": 34,
+                                        "end": 40
+                                    },
+                                    "flags": 0,
+                                    "start": 33,
+                                    "end": 40
+                                },
+                                "right": null,
+                                "flags": 32,
+                                "start": 29,
+                                "end": 40
+                            }
+                        ],
+                        "asyncKeyword": null,
+                        "returnType": null,
+                        "contents": {
+                            "kind": 134299649,
+                            "text": "T",
+                            "rawText": "T",
+                            "flags": 96,
+                            "start": 43,
+                            "end": 45
+                        },
+                        "flags": 32,
+                        "start": 29,
+                        "end": 45
+                    },
+                    "flags": 32,
+                    "start": 21,
+                    "end": 45
+                },
+                "flags": 32,
+                "start": 17,
+                "end": 45
+            },
+            "flags": 16,
+            "start": 17,
+            "end": 45
+        },
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 134299649,
+                "text": "T",
+                "rawText": "T",
+                "flags": 96,
+                "start": 48,
+                "end": 50
+            },
+            "flags": 16,
+            "start": 48,
+            "end": 50
+        },
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 134299649,
+                "text": "T",
+                "rawText": "T",
+                "flags": 96,
+                "start": 54,
+                "end": 56
+            },
+            "flags": 16,
+            "start": 54,
+            "end": 57
+        }
+    ],
+    "isModule": false,
+    "source": "type a = ((q | y, x?:string | (x?:string)=> T)=> T) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 57
+}
+```
+
+### Printed
+
+```javascript
+
+```
+
+### Diagnostics
+
+```javascript
+✖ Expected a `;` - start: 16, end: 17
+✖ Identifier expected - start: 20, end: 21
+✖ Expected a `;` - start: 41, end: 43
+✖ Expected a `;` - start: 45, end: 46
+✖ Declaration or statement expected - start: 46, end: 48
+✖ Expected a `;` - start: 50, end: 51
+✖ Declaration or statement expected - start: 51, end: 54
+
+```
+

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type30.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type30.md
@@ -1,0 +1,149 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (a[][][][][][]) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 261,
+                "arrowToken": {
+                    "kind": 10,
+                    "flags": 64,
+                    "start": 24,
+                    "end": 27
+                },
+                "parameters": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 136,
+                        "type": {
+                            "kind": 136,
+                            "type": {
+                                "kind": 136,
+                                "type": {
+                                    "kind": 136,
+                                    "type": {
+                                        "kind": 136,
+                                        "type": {
+                                            "kind": 136,
+                                            "type": {
+                                                "kind": 134299649,
+                                                "text": "a",
+                                                "rawText": "a",
+                                                "flags": 96,
+                                                "start": 10,
+                                                "end": 11
+                                            },
+                                            "flags": 0,
+                                            "start": 12,
+                                            "end": 13
+                                        },
+                                        "flags": 0,
+                                        "start": 14,
+                                        "end": 15
+                                    },
+                                    "flags": 0,
+                                    "start": 16,
+                                    "end": 17
+                                },
+                                "flags": 0,
+                                "start": 18,
+                                "end": 19
+                            },
+                            "flags": 0,
+                            "start": 20,
+                            "end": 21
+                        },
+                        "flags": 0,
+                        "start": 22,
+                        "end": 23
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 8,
+                    "end": 23
+                },
+                "returnType": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 134299649,
+                        "text": "T",
+                        "rawText": "T",
+                        "flags": 96,
+                        "start": 27,
+                        "end": 29
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 27,
+                    "end": 29
+                },
+                "typeParameters": null,
+                "flags": 0,
+                "start": 8,
+                "end": 29
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 30
+        }
+    ],
+    "isModule": false,
+    "source": "type a = (a[][][][][][]) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 30
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type33.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type33.md
@@ -3,7 +3,7 @@
 ## Input
 
 `````js
-type a = (a[a & b][][][][][]) => T;
+type a = (a[a & b][c | d][][][][]) => T;
 `````
 
 ## Options
@@ -46,8 +46,8 @@ type a = (a[a & b][][][][][]) => T;
                 "arrowToken": {
                     "kind": 10,
                     "flags": 64,
-                    "start": 29,
-                    "end": 32
+                    "start": 34,
+                    "end": 37
                 },
                 "parameters": {
                     "kind": 144,
@@ -60,8 +60,8 @@ type a = (a[a & b][][][][][]) => T;
                                 "type": {
                                     "kind": 136,
                                     "type": {
-                                        "kind": 136,
-                                        "type": {
+                                        "kind": 268,
+                                        "objectType": {
                                             "kind": 268,
                                             "objectType": {
                                                 "kind": 134299649,
@@ -113,30 +113,68 @@ type a = (a[a & b][][][][][]) => T;
                                             "start": 12,
                                             "end": 19
                                         },
+                                        "indexType": {
+                                            "kind": 137,
+                                            "types": [
+                                                {
+                                                    "kind": 144,
+                                                    "id": {
+                                                        "kind": 134299649,
+                                                        "text": "c",
+                                                        "rawText": "c",
+                                                        "flags": 96,
+                                                        "start": 19,
+                                                        "end": 20
+                                                    },
+                                                    "typeParameters": null,
+                                                    "flags": 0,
+                                                    "start": 19,
+                                                    "end": 20
+                                                },
+                                                {
+                                                    "kind": 144,
+                                                    "id": {
+                                                        "kind": 134299649,
+                                                        "text": "d",
+                                                        "rawText": "d",
+                                                        "flags": 96,
+                                                        "start": 22,
+                                                        "end": 24
+                                                    },
+                                                    "typeParameters": null,
+                                                    "flags": 0,
+                                                    "start": 22,
+                                                    "end": 24
+                                                }
+                                            ],
+                                            "flags": 0,
+                                            "start": 20,
+                                            "end": 24
+                                        },
                                         "flags": 0,
                                         "start": 19,
-                                        "end": 20
+                                        "end": 26
                                     },
                                     "flags": 0,
-                                    "start": 21,
-                                    "end": 22
+                                    "start": 26,
+                                    "end": 27
                                 },
                                 "flags": 0,
-                                "start": 23,
-                                "end": 24
+                                "start": 28,
+                                "end": 29
                             },
                             "flags": 0,
-                            "start": 25,
-                            "end": 26
+                            "start": 30,
+                            "end": 31
                         },
                         "flags": 0,
-                        "start": 27,
-                        "end": 28
+                        "start": 32,
+                        "end": 33
                     },
                     "typeParameters": null,
                     "flags": 0,
                     "start": 8,
-                    "end": 28
+                    "end": 33
                 },
                 "returnType": {
                     "kind": 144,
@@ -145,30 +183,30 @@ type a = (a[a & b][][][][][]) => T;
                         "text": "T",
                         "rawText": "T",
                         "flags": 96,
-                        "start": 32,
-                        "end": 34
+                        "start": 37,
+                        "end": 39
                     },
                     "typeParameters": null,
                     "flags": 0,
-                    "start": 32,
-                    "end": 34
+                    "start": 37,
+                    "end": 39
                 },
                 "typeParameters": null,
                 "flags": 0,
                 "start": 8,
-                "end": 34
+                "end": 39
             },
             "flags": 16,
             "start": 0,
-            "end": 35
+            "end": 40
         }
     ],
     "isModule": false,
-    "source": "type a = (a[a & b][][][][][]) => T;",
+    "source": "type a = (a[a & b][c | d][][][][]) => T;",
     "fileName": "__root__",
     "flags": 0,
     "start": 0,
-    "end": 35
+    "end": 40
 }
 ```
 

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type34.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type34.md
@@ -1,0 +1,273 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (a[a & b][c | d][{a():string}][][][]) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 261,
+                "arrowToken": {
+                    "kind": 10,
+                    "flags": 64,
+                    "start": 46,
+                    "end": 49
+                },
+                "parameters": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 136,
+                        "type": {
+                            "kind": 136,
+                            "type": {
+                                "kind": 136,
+                                "type": {
+                                    "kind": 268,
+                                    "objectType": {
+                                        "kind": 268,
+                                        "objectType": {
+                                            "kind": 268,
+                                            "objectType": {
+                                                "kind": 134299649,
+                                                "text": "a",
+                                                "rawText": "a",
+                                                "flags": 96,
+                                                "start": 10,
+                                                "end": 11
+                                            },
+                                            "indexType": {
+                                                "kind": 138,
+                                                "types": [
+                                                    {
+                                                        "kind": 144,
+                                                        "id": {
+                                                            "kind": 134299649,
+                                                            "text": "a",
+                                                            "rawText": "a",
+                                                            "flags": 96,
+                                                            "start": 12,
+                                                            "end": 13
+                                                        },
+                                                        "typeParameters": null,
+                                                        "flags": 0,
+                                                        "start": 12,
+                                                        "end": 13
+                                                    },
+                                                    {
+                                                        "kind": 144,
+                                                        "id": {
+                                                            "kind": 134299649,
+                                                            "text": "b",
+                                                            "rawText": "b",
+                                                            "flags": 96,
+                                                            "start": 15,
+                                                            "end": 17
+                                                        },
+                                                        "typeParameters": null,
+                                                        "flags": 0,
+                                                        "start": 15,
+                                                        "end": 17
+                                                    }
+                                                ],
+                                                "flags": 0,
+                                                "start": 13,
+                                                "end": 17
+                                            },
+                                            "flags": 0,
+                                            "start": 12,
+                                            "end": 19
+                                        },
+                                        "indexType": {
+                                            "kind": 137,
+                                            "types": [
+                                                {
+                                                    "kind": 144,
+                                                    "id": {
+                                                        "kind": 134299649,
+                                                        "text": "c",
+                                                        "rawText": "c",
+                                                        "flags": 96,
+                                                        "start": 19,
+                                                        "end": 20
+                                                    },
+                                                    "typeParameters": null,
+                                                    "flags": 0,
+                                                    "start": 19,
+                                                    "end": 20
+                                                },
+                                                {
+                                                    "kind": 144,
+                                                    "id": {
+                                                        "kind": 134299649,
+                                                        "text": "d",
+                                                        "rawText": "d",
+                                                        "flags": 96,
+                                                        "start": 22,
+                                                        "end": 24
+                                                    },
+                                                    "typeParameters": null,
+                                                    "flags": 0,
+                                                    "start": 22,
+                                                    "end": 24
+                                                }
+                                            ],
+                                            "flags": 0,
+                                            "start": 20,
+                                            "end": 24
+                                        },
+                                        "flags": 0,
+                                        "start": 19,
+                                        "end": 26
+                                    },
+                                    "indexType": {
+                                        "kind": 134234353,
+                                        "properties": [
+                                            {
+                                                "kind": 193,
+                                                "protoKeyword": null,
+                                                "staticToken": null,
+                                                "getKeyword": null,
+                                                "setKeyword": null,
+                                                "key": {
+                                                    "kind": 134299649,
+                                                    "text": "a",
+                                                    "rawText": "a",
+                                                    "flags": 96,
+                                                    "start": 27,
+                                                    "end": 28
+                                                },
+                                                "optionalToken": null,
+                                                "value": {
+                                                    "kind": 148,
+                                                    "parameters": {
+                                                        "kind": 208,
+                                                        "parameters": [],
+                                                        "trailingComma": false,
+                                                        "flags": 32,
+                                                        "start": 29,
+                                                        "end": 29
+                                                    },
+                                                    "returnType": {
+                                                        "kind": 134234347,
+                                                        "flags": 64,
+                                                        "start": 31,
+                                                        "end": 37
+                                                    },
+                                                    "typeParameters": null,
+                                                    "flags": 0,
+                                                    "start": 28,
+                                                    "end": 37
+                                                },
+                                                "flags": 0,
+                                                "start": 27,
+                                                "end": 37
+                                            }
+                                        ],
+                                        "flags": 0,
+                                        "start": 26,
+                                        "end": 38
+                                    },
+                                    "flags": 0,
+                                    "start": 26,
+                                    "end": 40
+                                },
+                                "flags": 0,
+                                "start": 40,
+                                "end": 41
+                            },
+                            "flags": 0,
+                            "start": 42,
+                            "end": 43
+                        },
+                        "flags": 0,
+                        "start": 44,
+                        "end": 45
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 8,
+                    "end": 45
+                },
+                "returnType": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 134299649,
+                        "text": "T",
+                        "rawText": "T",
+                        "flags": 96,
+                        "start": 49,
+                        "end": 51
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 49,
+                    "end": 51
+                },
+                "typeParameters": null,
+                "flags": 0,
+                "start": 8,
+                "end": 51
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 52
+        }
+    ],
+    "isModule": false,
+    "source": "type a = (a[a & b][c | d][{a():string}][][][]) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 52
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type35.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type35.md
@@ -1,0 +1,380 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (a[a & b[a|b|c|d|e]][c | d][(x) => T][][][]) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 260,
+                "type": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 136,
+                        "type": {
+                            "kind": 268,
+                            "objectType": {
+                                "kind": 268,
+                                "objectType": {
+                                    "kind": 134299649,
+                                    "text": "a",
+                                    "rawText": "a",
+                                    "flags": 96,
+                                    "start": 10,
+                                    "end": 11
+                                },
+                                "indexType": {
+                                    "kind": 138,
+                                    "types": [
+                                        {
+                                            "kind": 144,
+                                            "id": {
+                                                "kind": 134299649,
+                                                "text": "a",
+                                                "rawText": "a",
+                                                "flags": 96,
+                                                "start": 12,
+                                                "end": 13
+                                            },
+                                            "typeParameters": null,
+                                            "flags": 0,
+                                            "start": 12,
+                                            "end": 13
+                                        },
+                                        {
+                                            "kind": 268,
+                                            "objectType": {
+                                                "kind": 144,
+                                                "id": {
+                                                    "kind": 134299649,
+                                                    "text": "b",
+                                                    "rawText": "b",
+                                                    "flags": 96,
+                                                    "start": 15,
+                                                    "end": 17
+                                                },
+                                                "typeParameters": null,
+                                                "flags": 0,
+                                                "start": 15,
+                                                "end": 17
+                                            },
+                                            "indexType": {
+                                                "kind": 137,
+                                                "types": [
+                                                    {
+                                                        "kind": 144,
+                                                        "id": {
+                                                            "kind": 134299649,
+                                                            "text": "a",
+                                                            "rawText": "a",
+                                                            "flags": 96,
+                                                            "start": 18,
+                                                            "end": 19
+                                                        },
+                                                        "typeParameters": null,
+                                                        "flags": 0,
+                                                        "start": 18,
+                                                        "end": 19
+                                                    },
+                                                    {
+                                                        "kind": 144,
+                                                        "id": {
+                                                            "kind": 134299649,
+                                                            "text": "b",
+                                                            "rawText": "b",
+                                                            "flags": 96,
+                                                            "start": 20,
+                                                            "end": 21
+                                                        },
+                                                        "typeParameters": null,
+                                                        "flags": 0,
+                                                        "start": 20,
+                                                        "end": 21
+                                                    },
+                                                    {
+                                                        "kind": 144,
+                                                        "id": {
+                                                            "kind": 134299649,
+                                                            "text": "c",
+                                                            "rawText": "c",
+                                                            "flags": 96,
+                                                            "start": 22,
+                                                            "end": 23
+                                                        },
+                                                        "typeParameters": null,
+                                                        "flags": 0,
+                                                        "start": 22,
+                                                        "end": 23
+                                                    },
+                                                    {
+                                                        "kind": 144,
+                                                        "id": {
+                                                            "kind": 134299649,
+                                                            "text": "d",
+                                                            "rawText": "d",
+                                                            "flags": 96,
+                                                            "start": 24,
+                                                            "end": 25
+                                                        },
+                                                        "typeParameters": null,
+                                                        "flags": 0,
+                                                        "start": 24,
+                                                        "end": 25
+                                                    },
+                                                    {
+                                                        "kind": 144,
+                                                        "id": {
+                                                            "kind": 134299649,
+                                                            "text": "e",
+                                                            "rawText": "e",
+                                                            "flags": 96,
+                                                            "start": 26,
+                                                            "end": 27
+                                                        },
+                                                        "typeParameters": null,
+                                                        "flags": 0,
+                                                        "start": 26,
+                                                        "end": 27
+                                                    }
+                                                ],
+                                                "flags": 0,
+                                                "start": 19,
+                                                "end": 27
+                                            },
+                                            "flags": 0,
+                                            "start": 18,
+                                            "end": 29
+                                        }
+                                    ],
+                                    "flags": 0,
+                                    "start": 13,
+                                    "end": 28
+                                },
+                                "flags": 0,
+                                "start": 12,
+                                "end": 30
+                            },
+                            "indexType": {
+                                "kind": 137,
+                                "types": [
+                                    {
+                                        "kind": 144,
+                                        "id": {
+                                            "kind": 134299649,
+                                            "text": "c",
+                                            "rawText": "c",
+                                            "flags": 96,
+                                            "start": 30,
+                                            "end": 31
+                                        },
+                                        "typeParameters": null,
+                                        "flags": 0,
+                                        "start": 30,
+                                        "end": 31
+                                    },
+                                    {
+                                        "kind": 144,
+                                        "id": {
+                                            "kind": 134299649,
+                                            "text": "d",
+                                            "rawText": "d",
+                                            "flags": 96,
+                                            "start": 33,
+                                            "end": 35
+                                        },
+                                        "typeParameters": null,
+                                        "flags": 0,
+                                        "start": 33,
+                                        "end": 35
+                                    }
+                                ],
+                                "flags": 0,
+                                "start": 31,
+                                "end": 35
+                            },
+                            "flags": 0,
+                            "start": 30,
+                            "end": 37
+                        },
+                        "flags": 0,
+                        "start": 37,
+                        "end": 37
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 8,
+                    "end": 37
+                },
+                "flags": 0,
+                "start": 8,
+                "end": 37
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 37
+        },
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 271,
+                "arrowToken": {
+                    "kind": 10,
+                    "flags": 64,
+                    "start": 40,
+                    "end": 43
+                },
+                "typeParameters": null,
+                "parameters": [
+                    {
+                        "kind": 134299649,
+                        "text": "x",
+                        "rawText": "x",
+                        "flags": 96,
+                        "start": 38,
+                        "end": 39
+                    }
+                ],
+                "asyncKeyword": null,
+                "returnType": null,
+                "contents": {
+                    "kind": 134299649,
+                    "text": "T",
+                    "rawText": "T",
+                    "flags": 96,
+                    "start": 43,
+                    "end": 45
+                },
+                "flags": 32,
+                "start": 37,
+                "end": 45
+            },
+            "flags": 16,
+            "start": 37,
+            "end": 45
+        },
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 536871042,
+                "member": {
+                    "kind": 536871042,
+                    "member": {
+                        "kind": 119,
+                        "elementList": {
+                            "kind": 270,
+                            "elements": [],
+                            "trailingComma": false,
+                            "flags": 32,
+                            "start": 47,
+                            "end": 47
+                        },
+                        "flags": 32,
+                        "start": 46,
+                        "end": 48
+                    },
+                    "expression": {
+                        "kind": 16637,
+                        "text": "",
+                        "flags": 64,
+                        "start": 49,
+                        "end": 49
+                    },
+                    "flags": 32,
+                    "start": 46,
+                    "end": 50
+                },
+                "expression": {
+                    "kind": 16637,
+                    "text": "",
+                    "flags": 64,
+                    "start": 51,
+                    "end": 51
+                },
+                "flags": 32,
+                "start": 46,
+                "end": 52
+            },
+            "flags": 16,
+            "start": 46,
+            "end": 52
+        },
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 134299649,
+                "text": "T",
+                "rawText": "T",
+                "flags": 96,
+                "start": 56,
+                "end": 58
+            },
+            "flags": 16,
+            "start": 56,
+            "end": 59
+        }
+    ],
+    "isModule": false,
+    "source": "type a = (a[a & b[a|b|c|d|e]][c | d][(x) => T][][][]) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 59
+}
+```
+
+### Printed
+
+```javascript
+
+```
+
+### Diagnostics
+
+```javascript
+✖ Type expected - start: 37, end: 38
+✖ Expected a `;` - start: 45, end: 46
+✖ An member access expression should take an argument. - start: 46, end: 50
+✖ Identifier expected - start: 49, end: 50
+✖ An member access expression should take an argument. - start: 46, end: 52
+✖ Identifier expected - start: 51, end: 52
+✖ Expected a `;` - start: 52, end: 53
+✖ Declaration or statement expected - start: 53, end: 56
+
+```
+

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type36.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type36.md
@@ -1,0 +1,401 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (a[a & b[a|b|c|d|e]][c | d][(x) => T][-1][][]) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 260,
+                "type": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 136,
+                        "type": {
+                            "kind": 268,
+                            "objectType": {
+                                "kind": 268,
+                                "objectType": {
+                                    "kind": 134299649,
+                                    "text": "a",
+                                    "rawText": "a",
+                                    "flags": 96,
+                                    "start": 10,
+                                    "end": 11
+                                },
+                                "indexType": {
+                                    "kind": 138,
+                                    "types": [
+                                        {
+                                            "kind": 144,
+                                            "id": {
+                                                "kind": 134299649,
+                                                "text": "a",
+                                                "rawText": "a",
+                                                "flags": 96,
+                                                "start": 12,
+                                                "end": 13
+                                            },
+                                            "typeParameters": null,
+                                            "flags": 0,
+                                            "start": 12,
+                                            "end": 13
+                                        },
+                                        {
+                                            "kind": 268,
+                                            "objectType": {
+                                                "kind": 144,
+                                                "id": {
+                                                    "kind": 134299649,
+                                                    "text": "b",
+                                                    "rawText": "b",
+                                                    "flags": 96,
+                                                    "start": 15,
+                                                    "end": 17
+                                                },
+                                                "typeParameters": null,
+                                                "flags": 0,
+                                                "start": 15,
+                                                "end": 17
+                                            },
+                                            "indexType": {
+                                                "kind": 137,
+                                                "types": [
+                                                    {
+                                                        "kind": 144,
+                                                        "id": {
+                                                            "kind": 134299649,
+                                                            "text": "a",
+                                                            "rawText": "a",
+                                                            "flags": 96,
+                                                            "start": 18,
+                                                            "end": 19
+                                                        },
+                                                        "typeParameters": null,
+                                                        "flags": 0,
+                                                        "start": 18,
+                                                        "end": 19
+                                                    },
+                                                    {
+                                                        "kind": 144,
+                                                        "id": {
+                                                            "kind": 134299649,
+                                                            "text": "b",
+                                                            "rawText": "b",
+                                                            "flags": 96,
+                                                            "start": 20,
+                                                            "end": 21
+                                                        },
+                                                        "typeParameters": null,
+                                                        "flags": 0,
+                                                        "start": 20,
+                                                        "end": 21
+                                                    },
+                                                    {
+                                                        "kind": 144,
+                                                        "id": {
+                                                            "kind": 134299649,
+                                                            "text": "c",
+                                                            "rawText": "c",
+                                                            "flags": 96,
+                                                            "start": 22,
+                                                            "end": 23
+                                                        },
+                                                        "typeParameters": null,
+                                                        "flags": 0,
+                                                        "start": 22,
+                                                        "end": 23
+                                                    },
+                                                    {
+                                                        "kind": 144,
+                                                        "id": {
+                                                            "kind": 134299649,
+                                                            "text": "d",
+                                                            "rawText": "d",
+                                                            "flags": 96,
+                                                            "start": 24,
+                                                            "end": 25
+                                                        },
+                                                        "typeParameters": null,
+                                                        "flags": 0,
+                                                        "start": 24,
+                                                        "end": 25
+                                                    },
+                                                    {
+                                                        "kind": 144,
+                                                        "id": {
+                                                            "kind": 134299649,
+                                                            "text": "e",
+                                                            "rawText": "e",
+                                                            "flags": 96,
+                                                            "start": 26,
+                                                            "end": 27
+                                                        },
+                                                        "typeParameters": null,
+                                                        "flags": 0,
+                                                        "start": 26,
+                                                        "end": 27
+                                                    }
+                                                ],
+                                                "flags": 0,
+                                                "start": 19,
+                                                "end": 27
+                                            },
+                                            "flags": 0,
+                                            "start": 18,
+                                            "end": 29
+                                        }
+                                    ],
+                                    "flags": 0,
+                                    "start": 13,
+                                    "end": 28
+                                },
+                                "flags": 0,
+                                "start": 12,
+                                "end": 30
+                            },
+                            "indexType": {
+                                "kind": 137,
+                                "types": [
+                                    {
+                                        "kind": 144,
+                                        "id": {
+                                            "kind": 134299649,
+                                            "text": "c",
+                                            "rawText": "c",
+                                            "flags": 96,
+                                            "start": 30,
+                                            "end": 31
+                                        },
+                                        "typeParameters": null,
+                                        "flags": 0,
+                                        "start": 30,
+                                        "end": 31
+                                    },
+                                    {
+                                        "kind": 144,
+                                        "id": {
+                                            "kind": 134299649,
+                                            "text": "d",
+                                            "rawText": "d",
+                                            "flags": 96,
+                                            "start": 33,
+                                            "end": 35
+                                        },
+                                        "typeParameters": null,
+                                        "flags": 0,
+                                        "start": 33,
+                                        "end": 35
+                                    }
+                                ],
+                                "flags": 0,
+                                "start": 31,
+                                "end": 35
+                            },
+                            "flags": 0,
+                            "start": 30,
+                            "end": 37
+                        },
+                        "flags": 0,
+                        "start": 37,
+                        "end": 37
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 8,
+                    "end": 37
+                },
+                "flags": 0,
+                "start": 8,
+                "end": 37
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 37
+        },
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 271,
+                "arrowToken": {
+                    "kind": 10,
+                    "flags": 64,
+                    "start": 40,
+                    "end": 43
+                },
+                "typeParameters": null,
+                "parameters": [
+                    {
+                        "kind": 134299649,
+                        "text": "x",
+                        "rawText": "x",
+                        "flags": 96,
+                        "start": 38,
+                        "end": 39
+                    }
+                ],
+                "asyncKeyword": null,
+                "returnType": null,
+                "contents": {
+                    "kind": 134299649,
+                    "text": "T",
+                    "rawText": "T",
+                    "flags": 96,
+                    "start": 43,
+                    "end": 45
+                },
+                "flags": 32,
+                "start": 37,
+                "end": 45
+            },
+            "flags": 16,
+            "start": 37,
+            "end": 45
+        },
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 536871042,
+                "member": {
+                    "kind": 536871042,
+                    "member": {
+                        "kind": 119,
+                        "elementList": {
+                            "kind": 270,
+                            "elements": [
+                                {
+                                    "kind": 126,
+                                    "operandToken": {
+                                        "kind": 100915,
+                                        "flags": 64,
+                                        "start": 47,
+                                        "end": 48
+                                    },
+                                    "operand": {
+                                        "kind": 201392130,
+                                        "text": 1,
+                                        "rawText": "1",
+                                        "flags": 96,
+                                        "start": 48,
+                                        "end": 49
+                                    },
+                                    "flags": 32,
+                                    "start": 47,
+                                    "end": 49
+                                }
+                            ],
+                            "trailingComma": false,
+                            "flags": 32,
+                            "start": 47,
+                            "end": 49
+                        },
+                        "flags": 32,
+                        "start": 46,
+                        "end": 50
+                    },
+                    "expression": {
+                        "kind": 16637,
+                        "text": "",
+                        "flags": 64,
+                        "start": 51,
+                        "end": 51
+                    },
+                    "flags": 32,
+                    "start": 46,
+                    "end": 52
+                },
+                "expression": {
+                    "kind": 16637,
+                    "text": "",
+                    "flags": 64,
+                    "start": 53,
+                    "end": 53
+                },
+                "flags": 32,
+                "start": 46,
+                "end": 54
+            },
+            "flags": 16,
+            "start": 46,
+            "end": 54
+        },
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 134299649,
+                "text": "T",
+                "rawText": "T",
+                "flags": 96,
+                "start": 58,
+                "end": 60
+            },
+            "flags": 16,
+            "start": 58,
+            "end": 61
+        }
+    ],
+    "isModule": false,
+    "source": "type a = (a[a & b[a|b|c|d|e]][c | d][(x) => T][-1][][]) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 61
+}
+```
+
+### Printed
+
+```javascript
+
+```
+
+### Diagnostics
+
+```javascript
+✖ Type expected - start: 37, end: 38
+✖ Expected a `;` - start: 45, end: 46
+✖ An member access expression should take an argument. - start: 46, end: 52
+✖ Identifier expected - start: 51, end: 52
+✖ An member access expression should take an argument. - start: 46, end: 54
+✖ Identifier expected - start: 53, end: 54
+✖ Expected a `;` - start: 54, end: 55
+✖ Declaration or statement expected - start: 55, end: 58
+
+```
+

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type36.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type36.md
@@ -302,7 +302,7 @@ type a = (a[a & b[a|b|c|d|e]][c | d][(x) => T][-1][][]) => T;
                                 {
                                     "kind": 126,
                                     "operandToken": {
-                                        "kind": 100915,
+                                        "kind": 134318643,
                                         "flags": 64,
                                         "start": 47,
                                         "end": 48

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type37.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type37.md
@@ -302,7 +302,7 @@ type a = (a[a & b[a|b|c|d|e]][c | d][(x) => T][-1][{...x}][]) => T;
                                 {
                                     "kind": 126,
                                     "operandToken": {
-                                        "kind": 100915,
+                                        "kind": 134318643,
                                         "flags": 64,
                                         "start": 47,
                                         "end": 48

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type37.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type37.md
@@ -1,0 +1,427 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (a[a & b[a|b|c|d|e]][c | d][(x) => T][-1][{...x}][]) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 260,
+                "type": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 136,
+                        "type": {
+                            "kind": 268,
+                            "objectType": {
+                                "kind": 268,
+                                "objectType": {
+                                    "kind": 134299649,
+                                    "text": "a",
+                                    "rawText": "a",
+                                    "flags": 96,
+                                    "start": 10,
+                                    "end": 11
+                                },
+                                "indexType": {
+                                    "kind": 138,
+                                    "types": [
+                                        {
+                                            "kind": 144,
+                                            "id": {
+                                                "kind": 134299649,
+                                                "text": "a",
+                                                "rawText": "a",
+                                                "flags": 96,
+                                                "start": 12,
+                                                "end": 13
+                                            },
+                                            "typeParameters": null,
+                                            "flags": 0,
+                                            "start": 12,
+                                            "end": 13
+                                        },
+                                        {
+                                            "kind": 268,
+                                            "objectType": {
+                                                "kind": 144,
+                                                "id": {
+                                                    "kind": 134299649,
+                                                    "text": "b",
+                                                    "rawText": "b",
+                                                    "flags": 96,
+                                                    "start": 15,
+                                                    "end": 17
+                                                },
+                                                "typeParameters": null,
+                                                "flags": 0,
+                                                "start": 15,
+                                                "end": 17
+                                            },
+                                            "indexType": {
+                                                "kind": 137,
+                                                "types": [
+                                                    {
+                                                        "kind": 144,
+                                                        "id": {
+                                                            "kind": 134299649,
+                                                            "text": "a",
+                                                            "rawText": "a",
+                                                            "flags": 96,
+                                                            "start": 18,
+                                                            "end": 19
+                                                        },
+                                                        "typeParameters": null,
+                                                        "flags": 0,
+                                                        "start": 18,
+                                                        "end": 19
+                                                    },
+                                                    {
+                                                        "kind": 144,
+                                                        "id": {
+                                                            "kind": 134299649,
+                                                            "text": "b",
+                                                            "rawText": "b",
+                                                            "flags": 96,
+                                                            "start": 20,
+                                                            "end": 21
+                                                        },
+                                                        "typeParameters": null,
+                                                        "flags": 0,
+                                                        "start": 20,
+                                                        "end": 21
+                                                    },
+                                                    {
+                                                        "kind": 144,
+                                                        "id": {
+                                                            "kind": 134299649,
+                                                            "text": "c",
+                                                            "rawText": "c",
+                                                            "flags": 96,
+                                                            "start": 22,
+                                                            "end": 23
+                                                        },
+                                                        "typeParameters": null,
+                                                        "flags": 0,
+                                                        "start": 22,
+                                                        "end": 23
+                                                    },
+                                                    {
+                                                        "kind": 144,
+                                                        "id": {
+                                                            "kind": 134299649,
+                                                            "text": "d",
+                                                            "rawText": "d",
+                                                            "flags": 96,
+                                                            "start": 24,
+                                                            "end": 25
+                                                        },
+                                                        "typeParameters": null,
+                                                        "flags": 0,
+                                                        "start": 24,
+                                                        "end": 25
+                                                    },
+                                                    {
+                                                        "kind": 144,
+                                                        "id": {
+                                                            "kind": 134299649,
+                                                            "text": "e",
+                                                            "rawText": "e",
+                                                            "flags": 96,
+                                                            "start": 26,
+                                                            "end": 27
+                                                        },
+                                                        "typeParameters": null,
+                                                        "flags": 0,
+                                                        "start": 26,
+                                                        "end": 27
+                                                    }
+                                                ],
+                                                "flags": 0,
+                                                "start": 19,
+                                                "end": 27
+                                            },
+                                            "flags": 0,
+                                            "start": 18,
+                                            "end": 29
+                                        }
+                                    ],
+                                    "flags": 0,
+                                    "start": 13,
+                                    "end": 28
+                                },
+                                "flags": 0,
+                                "start": 12,
+                                "end": 30
+                            },
+                            "indexType": {
+                                "kind": 137,
+                                "types": [
+                                    {
+                                        "kind": 144,
+                                        "id": {
+                                            "kind": 134299649,
+                                            "text": "c",
+                                            "rawText": "c",
+                                            "flags": 96,
+                                            "start": 30,
+                                            "end": 31
+                                        },
+                                        "typeParameters": null,
+                                        "flags": 0,
+                                        "start": 30,
+                                        "end": 31
+                                    },
+                                    {
+                                        "kind": 144,
+                                        "id": {
+                                            "kind": 134299649,
+                                            "text": "d",
+                                            "rawText": "d",
+                                            "flags": 96,
+                                            "start": 33,
+                                            "end": 35
+                                        },
+                                        "typeParameters": null,
+                                        "flags": 0,
+                                        "start": 33,
+                                        "end": 35
+                                    }
+                                ],
+                                "flags": 0,
+                                "start": 31,
+                                "end": 35
+                            },
+                            "flags": 0,
+                            "start": 30,
+                            "end": 37
+                        },
+                        "flags": 0,
+                        "start": 37,
+                        "end": 37
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 8,
+                    "end": 37
+                },
+                "flags": 0,
+                "start": 8,
+                "end": 37
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 37
+        },
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 271,
+                "arrowToken": {
+                    "kind": 10,
+                    "flags": 64,
+                    "start": 40,
+                    "end": 43
+                },
+                "typeParameters": null,
+                "parameters": [
+                    {
+                        "kind": 134299649,
+                        "text": "x",
+                        "rawText": "x",
+                        "flags": 96,
+                        "start": 38,
+                        "end": 39
+                    }
+                ],
+                "asyncKeyword": null,
+                "returnType": null,
+                "contents": {
+                    "kind": 134299649,
+                    "text": "T",
+                    "rawText": "T",
+                    "flags": 96,
+                    "start": 43,
+                    "end": 45
+                },
+                "flags": 32,
+                "start": 37,
+                "end": 45
+            },
+            "flags": 16,
+            "start": 37,
+            "end": 45
+        },
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 536871042,
+                "member": {
+                    "kind": 536871042,
+                    "member": {
+                        "kind": 119,
+                        "elementList": {
+                            "kind": 270,
+                            "elements": [
+                                {
+                                    "kind": 126,
+                                    "operandToken": {
+                                        "kind": 100915,
+                                        "flags": 64,
+                                        "start": 47,
+                                        "end": 48
+                                    },
+                                    "operand": {
+                                        "kind": 201392130,
+                                        "text": 1,
+                                        "rawText": "1",
+                                        "flags": 96,
+                                        "start": 48,
+                                        "end": 49
+                                    },
+                                    "flags": 32,
+                                    "start": 47,
+                                    "end": 49
+                                }
+                            ],
+                            "trailingComma": false,
+                            "flags": 32,
+                            "start": 47,
+                            "end": 49
+                        },
+                        "flags": 32,
+                        "start": 46,
+                        "end": 50
+                    },
+                    "expression": {
+                        "kind": 220,
+                        "propertyList": {
+                            "kind": 218,
+                            "properties": [
+                                {
+                                    "kind": 224,
+                                    "ellipsisToken": {
+                                        "kind": 524302,
+                                        "flags": 64,
+                                        "start": 52,
+                                        "end": 55
+                                    },
+                                    "argument": {
+                                        "kind": 134299649,
+                                        "text": "x",
+                                        "rawText": "x",
+                                        "flags": 96,
+                                        "start": 55,
+                                        "end": 56
+                                    },
+                                    "flags": 32,
+                                    "start": 52,
+                                    "end": 56
+                                }
+                            ],
+                            "trailingComma": false,
+                            "flags": 16,
+                            "start": 52,
+                            "end": 56
+                        },
+                        "flags": 48,
+                        "start": 51,
+                        "end": 57
+                    },
+                    "flags": 32,
+                    "start": 46,
+                    "end": 58
+                },
+                "expression": {
+                    "kind": 16637,
+                    "text": "",
+                    "flags": 64,
+                    "start": 59,
+                    "end": 59
+                },
+                "flags": 32,
+                "start": 46,
+                "end": 60
+            },
+            "flags": 16,
+            "start": 46,
+            "end": 60
+        },
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 134299649,
+                "text": "T",
+                "rawText": "T",
+                "flags": 96,
+                "start": 64,
+                "end": 66
+            },
+            "flags": 16,
+            "start": 64,
+            "end": 67
+        }
+    ],
+    "isModule": false,
+    "source": "type a = (a[a & b[a|b|c|d|e]][c | d][(x) => T][-1][{...x}][]) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 67
+}
+```
+
+### Printed
+
+```javascript
+
+```
+
+### Diagnostics
+
+```javascript
+✖ Type expected - start: 37, end: 38
+✖ Expected a `;` - start: 45, end: 46
+✖ An member access expression should take an argument. - start: 46, end: 60
+✖ Identifier expected - start: 59, end: 60
+✖ Expected a `;` - start: 60, end: 61
+✖ Declaration or statement expected - start: 61, end: 64
+
+```
+

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type38.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type38.md
@@ -3,7 +3,7 @@
 ## Input
 
 `````js
-type a = (1) => T;
+type a = (...x) => T;
 `````
 
 ## Options
@@ -46,24 +46,46 @@ type a = (1) => T;
                 "arrowToken": {
                     "kind": 10,
                     "flags": 64,
-                    "start": 12,
-                    "end": 15
+                    "start": 15,
+                    "end": 18
                 },
                 "parameters": {
-                    "kind": 279,
+                    "kind": 208,
                     "parameters": [
                         {
-                            "kind": 134217968,
-                            "value": 1,
+                            "kind": 149,
+                            "ellipsisToken": {
+                                "kind": 524302,
+                                "flags": 64,
+                                "start": 10,
+                                "end": 13
+                            },
+                            "name": null,
+                            "optionalToken": null,
+                            "types": {
+                                "kind": 144,
+                                "id": {
+                                    "kind": 134299649,
+                                    "text": "x",
+                                    "rawText": "x",
+                                    "flags": 96,
+                                    "start": 13,
+                                    "end": 14
+                                },
+                                "typeParameters": null,
+                                "flags": 0,
+                                "start": 13,
+                                "end": 14
+                            },
                             "flags": 0,
                             "start": 10,
-                            "end": 11
+                            "end": 14
                         }
                     ],
                     "trailingComma": false,
                     "flags": 32,
-                    "start": 8,
-                    "end": 15
+                    "start": 10,
+                    "end": 14
                 },
                 "returnType": {
                     "kind": 144,
@@ -72,30 +94,30 @@ type a = (1) => T;
                         "text": "T",
                         "rawText": "T",
                         "flags": 96,
-                        "start": 15,
-                        "end": 17
+                        "start": 18,
+                        "end": 20
                     },
                     "typeParameters": null,
                     "flags": 0,
-                    "start": 15,
-                    "end": 17
+                    "start": 18,
+                    "end": 20
                 },
                 "typeParameters": null,
                 "flags": 0,
                 "start": 8,
-                "end": 17
+                "end": 20
             },
             "flags": 16,
             "start": 0,
-            "end": 18
+            "end": 21
         }
     ],
     "isModule": false,
-    "source": "type a = (1) => T;",
+    "source": "type a = (...x) => T;",
     "fileName": "__root__",
     "flags": 0,
     "start": 0,
-    "end": 18
+    "end": 21
 }
 ```
 

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type39.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type39.md
@@ -3,7 +3,7 @@
 ## Input
 
 `````js
-type a = (1) => T;
+type a = (...x: string) => T;
 `````
 
 ## Options
@@ -46,24 +46,44 @@ type a = (1) => T;
                 "arrowToken": {
                     "kind": 10,
                     "flags": 64,
-                    "start": 12,
-                    "end": 15
+                    "start": 23,
+                    "end": 26
                 },
                 "parameters": {
-                    "kind": 279,
+                    "kind": 208,
                     "parameters": [
                         {
-                            "kind": 134217968,
-                            "value": 1,
+                            "kind": 149,
+                            "ellipsisToken": {
+                                "kind": 524302,
+                                "flags": 64,
+                                "start": 10,
+                                "end": 13
+                            },
+                            "name": {
+                                "kind": 134299649,
+                                "text": "x",
+                                "rawText": "x",
+                                "flags": 96,
+                                "start": 13,
+                                "end": 14
+                            },
+                            "optionalToken": null,
+                            "types": {
+                                "kind": 134234347,
+                                "flags": 64,
+                                "start": 15,
+                                "end": 22
+                            },
                             "flags": 0,
                             "start": 10,
-                            "end": 11
+                            "end": 22
                         }
                     ],
                     "trailingComma": false,
                     "flags": 32,
-                    "start": 8,
-                    "end": 15
+                    "start": 10,
+                    "end": 22
                 },
                 "returnType": {
                     "kind": 144,
@@ -72,30 +92,30 @@ type a = (1) => T;
                         "text": "T",
                         "rawText": "T",
                         "flags": 96,
-                        "start": 15,
-                        "end": 17
+                        "start": 26,
+                        "end": 28
                     },
                     "typeParameters": null,
                     "flags": 0,
-                    "start": 15,
-                    "end": 17
+                    "start": 26,
+                    "end": 28
                 },
                 "typeParameters": null,
                 "flags": 0,
                 "start": 8,
-                "end": 17
+                "end": 28
             },
             "flags": 16,
             "start": 0,
-            "end": 18
+            "end": 29
         }
     ],
     "isModule": false,
-    "source": "type a = (1) => T;",
+    "source": "type a = (...x: string) => T;",
     "fileName": "__root__",
     "flags": 0,
     "start": 0,
-    "end": 18
+    "end": 29
 }
 ```
 

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type40.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type40.md
@@ -1,0 +1,180 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (...x: string & foo | bar) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 261,
+                "arrowToken": {
+                    "kind": 10,
+                    "flags": 64,
+                    "start": 35,
+                    "end": 38
+                },
+                "parameters": {
+                    "kind": 208,
+                    "parameters": [
+                        {
+                            "kind": 149,
+                            "ellipsisToken": {
+                                "kind": 524302,
+                                "flags": 64,
+                                "start": 10,
+                                "end": 13
+                            },
+                            "name": {
+                                "kind": 134299649,
+                                "text": "x",
+                                "rawText": "x",
+                                "flags": 96,
+                                "start": 13,
+                                "end": 14
+                            },
+                            "optionalToken": null,
+                            "types": {
+                                "kind": 137,
+                                "types": [
+                                    {
+                                        "kind": 138,
+                                        "types": [
+                                            {
+                                                "kind": 134234347,
+                                                "flags": 64,
+                                                "start": 15,
+                                                "end": 22
+                                            },
+                                            {
+                                                "kind": 144,
+                                                "id": {
+                                                    "kind": 134299649,
+                                                    "text": "foo",
+                                                    "rawText": "foo",
+                                                    "flags": 96,
+                                                    "start": 24,
+                                                    "end": 28
+                                                },
+                                                "typeParameters": null,
+                                                "flags": 0,
+                                                "start": 24,
+                                                "end": 28
+                                            }
+                                        ],
+                                        "flags": 0,
+                                        "start": 22,
+                                        "end": 28
+                                    },
+                                    {
+                                        "kind": 144,
+                                        "id": {
+                                            "kind": 134299649,
+                                            "text": "bar",
+                                            "rawText": "bar",
+                                            "flags": 96,
+                                            "start": 30,
+                                            "end": 34
+                                        },
+                                        "typeParameters": null,
+                                        "flags": 0,
+                                        "start": 30,
+                                        "end": 34
+                                    }
+                                ],
+                                "flags": 0,
+                                "start": 28,
+                                "end": 34
+                            },
+                            "flags": 0,
+                            "start": 10,
+                            "end": 34
+                        }
+                    ],
+                    "trailingComma": false,
+                    "flags": 32,
+                    "start": 10,
+                    "end": 34
+                },
+                "returnType": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 134299649,
+                        "text": "T",
+                        "rawText": "T",
+                        "flags": 96,
+                        "start": 38,
+                        "end": 40
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 38,
+                    "end": 40
+                },
+                "typeParameters": null,
+                "flags": 0,
+                "start": 8,
+                "end": 40
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 41
+        }
+    ],
+    "isModule": false,
+    "source": "type a = (...x: string & foo | bar) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 41
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type41.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type41.md
@@ -1,0 +1,275 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (...x: string & foo | (...x: string & foo | bar) => T) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 261,
+                "arrowToken": {
+                    "kind": 10,
+                    "flags": 64,
+                    "start": 63,
+                    "end": 66
+                },
+                "parameters": {
+                    "kind": 208,
+                    "parameters": [
+                        {
+                            "kind": 149,
+                            "ellipsisToken": {
+                                "kind": 524302,
+                                "flags": 64,
+                                "start": 10,
+                                "end": 13
+                            },
+                            "name": {
+                                "kind": 134299649,
+                                "text": "x",
+                                "rawText": "x",
+                                "flags": 96,
+                                "start": 13,
+                                "end": 14
+                            },
+                            "optionalToken": null,
+                            "types": {
+                                "kind": 137,
+                                "types": [
+                                    {
+                                        "kind": 138,
+                                        "types": [
+                                            {
+                                                "kind": 134234347,
+                                                "flags": 64,
+                                                "start": 15,
+                                                "end": 22
+                                            },
+                                            {
+                                                "kind": 144,
+                                                "id": {
+                                                    "kind": 134299649,
+                                                    "text": "foo",
+                                                    "rawText": "foo",
+                                                    "flags": 96,
+                                                    "start": 24,
+                                                    "end": 28
+                                                },
+                                                "typeParameters": null,
+                                                "flags": 0,
+                                                "start": 24,
+                                                "end": 28
+                                            }
+                                        ],
+                                        "flags": 0,
+                                        "start": 22,
+                                        "end": 28
+                                    },
+                                    {
+                                        "kind": 261,
+                                        "arrowToken": {
+                                            "kind": 10,
+                                            "flags": 64,
+                                            "start": 57,
+                                            "end": 60
+                                        },
+                                        "parameters": {
+                                            "kind": 208,
+                                            "parameters": [
+                                                {
+                                                    "kind": 149,
+                                                    "ellipsisToken": {
+                                                        "kind": 524302,
+                                                        "flags": 64,
+                                                        "start": 32,
+                                                        "end": 35
+                                                    },
+                                                    "name": {
+                                                        "kind": 134299649,
+                                                        "text": "x",
+                                                        "rawText": "x",
+                                                        "flags": 96,
+                                                        "start": 35,
+                                                        "end": 36
+                                                    },
+                                                    "optionalToken": null,
+                                                    "types": {
+                                                        "kind": 137,
+                                                        "types": [
+                                                            {
+                                                                "kind": 138,
+                                                                "types": [
+                                                                    {
+                                                                        "kind": 134234347,
+                                                                        "flags": 64,
+                                                                        "start": 37,
+                                                                        "end": 44
+                                                                    },
+                                                                    {
+                                                                        "kind": 144,
+                                                                        "id": {
+                                                                            "kind": 134299649,
+                                                                            "text": "foo",
+                                                                            "rawText": "foo",
+                                                                            "flags": 96,
+                                                                            "start": 46,
+                                                                            "end": 50
+                                                                        },
+                                                                        "typeParameters": null,
+                                                                        "flags": 0,
+                                                                        "start": 46,
+                                                                        "end": 50
+                                                                    }
+                                                                ],
+                                                                "flags": 0,
+                                                                "start": 44,
+                                                                "end": 50
+                                                            },
+                                                            {
+                                                                "kind": 144,
+                                                                "id": {
+                                                                    "kind": 134299649,
+                                                                    "text": "bar",
+                                                                    "rawText": "bar",
+                                                                    "flags": 96,
+                                                                    "start": 52,
+                                                                    "end": 56
+                                                                },
+                                                                "typeParameters": null,
+                                                                "flags": 0,
+                                                                "start": 52,
+                                                                "end": 56
+                                                            }
+                                                        ],
+                                                        "flags": 0,
+                                                        "start": 50,
+                                                        "end": 56
+                                                    },
+                                                    "flags": 0,
+                                                    "start": 32,
+                                                    "end": 56
+                                                }
+                                            ],
+                                            "trailingComma": false,
+                                            "flags": 32,
+                                            "start": 32,
+                                            "end": 56
+                                        },
+                                        "returnType": {
+                                            "kind": 144,
+                                            "id": {
+                                                "kind": 134299649,
+                                                "text": "T",
+                                                "rawText": "T",
+                                                "flags": 96,
+                                                "start": 60,
+                                                "end": 62
+                                            },
+                                            "typeParameters": null,
+                                            "flags": 0,
+                                            "start": 60,
+                                            "end": 62
+                                        },
+                                        "typeParameters": null,
+                                        "flags": 0,
+                                        "start": 30,
+                                        "end": 62
+                                    }
+                                ],
+                                "flags": 0,
+                                "start": 28,
+                                "end": 62
+                            },
+                            "flags": 0,
+                            "start": 10,
+                            "end": 62
+                        }
+                    ],
+                    "trailingComma": false,
+                    "flags": 32,
+                    "start": 10,
+                    "end": 62
+                },
+                "returnType": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 134299649,
+                        "text": "T",
+                        "rawText": "T",
+                        "flags": 96,
+                        "start": 66,
+                        "end": 68
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 66,
+                    "end": 68
+                },
+                "typeParameters": null,
+                "flags": 0,
+                "start": 8,
+                "end": 68
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 69
+        }
+    ],
+    "isModule": false,
+    "source": "type a = (...x: string & foo | (...x: string & foo | bar) => T) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 69
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type42.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type42.md
@@ -1,0 +1,280 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (...x?: string & foo | (...x: string & foo | bar) => T) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 261,
+                "arrowToken": {
+                    "kind": 10,
+                    "flags": 64,
+                    "start": 64,
+                    "end": 67
+                },
+                "parameters": {
+                    "kind": 208,
+                    "parameters": [
+                        {
+                            "kind": 149,
+                            "ellipsisToken": {
+                                "kind": 524302,
+                                "flags": 64,
+                                "start": 10,
+                                "end": 13
+                            },
+                            "name": {
+                                "kind": 134299649,
+                                "text": "x",
+                                "rawText": "x",
+                                "flags": 96,
+                                "start": 13,
+                                "end": 14
+                            },
+                            "optionalToken": {
+                                "kind": 134217750,
+                                "flags": 64,
+                                "start": 14,
+                                "end": 15
+                            },
+                            "types": {
+                                "kind": 137,
+                                "types": [
+                                    {
+                                        "kind": 138,
+                                        "types": [
+                                            {
+                                                "kind": 134234347,
+                                                "flags": 64,
+                                                "start": 16,
+                                                "end": 23
+                                            },
+                                            {
+                                                "kind": 144,
+                                                "id": {
+                                                    "kind": 134299649,
+                                                    "text": "foo",
+                                                    "rawText": "foo",
+                                                    "flags": 96,
+                                                    "start": 25,
+                                                    "end": 29
+                                                },
+                                                "typeParameters": null,
+                                                "flags": 0,
+                                                "start": 25,
+                                                "end": 29
+                                            }
+                                        ],
+                                        "flags": 0,
+                                        "start": 23,
+                                        "end": 29
+                                    },
+                                    {
+                                        "kind": 261,
+                                        "arrowToken": {
+                                            "kind": 10,
+                                            "flags": 64,
+                                            "start": 58,
+                                            "end": 61
+                                        },
+                                        "parameters": {
+                                            "kind": 208,
+                                            "parameters": [
+                                                {
+                                                    "kind": 149,
+                                                    "ellipsisToken": {
+                                                        "kind": 524302,
+                                                        "flags": 64,
+                                                        "start": 33,
+                                                        "end": 36
+                                                    },
+                                                    "name": {
+                                                        "kind": 134299649,
+                                                        "text": "x",
+                                                        "rawText": "x",
+                                                        "flags": 96,
+                                                        "start": 36,
+                                                        "end": 37
+                                                    },
+                                                    "optionalToken": null,
+                                                    "types": {
+                                                        "kind": 137,
+                                                        "types": [
+                                                            {
+                                                                "kind": 138,
+                                                                "types": [
+                                                                    {
+                                                                        "kind": 134234347,
+                                                                        "flags": 64,
+                                                                        "start": 38,
+                                                                        "end": 45
+                                                                    },
+                                                                    {
+                                                                        "kind": 144,
+                                                                        "id": {
+                                                                            "kind": 134299649,
+                                                                            "text": "foo",
+                                                                            "rawText": "foo",
+                                                                            "flags": 96,
+                                                                            "start": 47,
+                                                                            "end": 51
+                                                                        },
+                                                                        "typeParameters": null,
+                                                                        "flags": 0,
+                                                                        "start": 47,
+                                                                        "end": 51
+                                                                    }
+                                                                ],
+                                                                "flags": 0,
+                                                                "start": 45,
+                                                                "end": 51
+                                                            },
+                                                            {
+                                                                "kind": 144,
+                                                                "id": {
+                                                                    "kind": 134299649,
+                                                                    "text": "bar",
+                                                                    "rawText": "bar",
+                                                                    "flags": 96,
+                                                                    "start": 53,
+                                                                    "end": 57
+                                                                },
+                                                                "typeParameters": null,
+                                                                "flags": 0,
+                                                                "start": 53,
+                                                                "end": 57
+                                                            }
+                                                        ],
+                                                        "flags": 0,
+                                                        "start": 51,
+                                                        "end": 57
+                                                    },
+                                                    "flags": 0,
+                                                    "start": 33,
+                                                    "end": 57
+                                                }
+                                            ],
+                                            "trailingComma": false,
+                                            "flags": 32,
+                                            "start": 33,
+                                            "end": 57
+                                        },
+                                        "returnType": {
+                                            "kind": 144,
+                                            "id": {
+                                                "kind": 134299649,
+                                                "text": "T",
+                                                "rawText": "T",
+                                                "flags": 96,
+                                                "start": 61,
+                                                "end": 63
+                                            },
+                                            "typeParameters": null,
+                                            "flags": 0,
+                                            "start": 61,
+                                            "end": 63
+                                        },
+                                        "typeParameters": null,
+                                        "flags": 0,
+                                        "start": 31,
+                                        "end": 63
+                                    }
+                                ],
+                                "flags": 0,
+                                "start": 29,
+                                "end": 63
+                            },
+                            "flags": 0,
+                            "start": 10,
+                            "end": 63
+                        }
+                    ],
+                    "trailingComma": false,
+                    "flags": 32,
+                    "start": 10,
+                    "end": 63
+                },
+                "returnType": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 134299649,
+                        "text": "T",
+                        "rawText": "T",
+                        "flags": 96,
+                        "start": 67,
+                        "end": 69
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 67,
+                    "end": 69
+                },
+                "typeParameters": null,
+                "flags": 0,
+                "start": 8,
+                "end": 69
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 70
+        }
+    ],
+    "isModule": false,
+    "source": "type a = (...x?: string & foo | (...x: string & foo | bar) => T) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 70
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type43.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type43.md
@@ -1,0 +1,285 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (...x?: string & foo | (...x?: string & foo | bar) => T) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 261,
+                "arrowToken": {
+                    "kind": 10,
+                    "flags": 64,
+                    "start": 65,
+                    "end": 68
+                },
+                "parameters": {
+                    "kind": 208,
+                    "parameters": [
+                        {
+                            "kind": 149,
+                            "ellipsisToken": {
+                                "kind": 524302,
+                                "flags": 64,
+                                "start": 10,
+                                "end": 13
+                            },
+                            "name": {
+                                "kind": 134299649,
+                                "text": "x",
+                                "rawText": "x",
+                                "flags": 96,
+                                "start": 13,
+                                "end": 14
+                            },
+                            "optionalToken": {
+                                "kind": 134217750,
+                                "flags": 64,
+                                "start": 14,
+                                "end": 15
+                            },
+                            "types": {
+                                "kind": 137,
+                                "types": [
+                                    {
+                                        "kind": 138,
+                                        "types": [
+                                            {
+                                                "kind": 134234347,
+                                                "flags": 64,
+                                                "start": 16,
+                                                "end": 23
+                                            },
+                                            {
+                                                "kind": 144,
+                                                "id": {
+                                                    "kind": 134299649,
+                                                    "text": "foo",
+                                                    "rawText": "foo",
+                                                    "flags": 96,
+                                                    "start": 25,
+                                                    "end": 29
+                                                },
+                                                "typeParameters": null,
+                                                "flags": 0,
+                                                "start": 25,
+                                                "end": 29
+                                            }
+                                        ],
+                                        "flags": 0,
+                                        "start": 23,
+                                        "end": 29
+                                    },
+                                    {
+                                        "kind": 261,
+                                        "arrowToken": {
+                                            "kind": 10,
+                                            "flags": 64,
+                                            "start": 59,
+                                            "end": 62
+                                        },
+                                        "parameters": {
+                                            "kind": 208,
+                                            "parameters": [
+                                                {
+                                                    "kind": 149,
+                                                    "ellipsisToken": {
+                                                        "kind": 524302,
+                                                        "flags": 64,
+                                                        "start": 33,
+                                                        "end": 36
+                                                    },
+                                                    "name": {
+                                                        "kind": 134299649,
+                                                        "text": "x",
+                                                        "rawText": "x",
+                                                        "flags": 96,
+                                                        "start": 36,
+                                                        "end": 37
+                                                    },
+                                                    "optionalToken": {
+                                                        "kind": 134217750,
+                                                        "flags": 64,
+                                                        "start": 37,
+                                                        "end": 38
+                                                    },
+                                                    "types": {
+                                                        "kind": 137,
+                                                        "types": [
+                                                            {
+                                                                "kind": 138,
+                                                                "types": [
+                                                                    {
+                                                                        "kind": 134234347,
+                                                                        "flags": 64,
+                                                                        "start": 39,
+                                                                        "end": 46
+                                                                    },
+                                                                    {
+                                                                        "kind": 144,
+                                                                        "id": {
+                                                                            "kind": 134299649,
+                                                                            "text": "foo",
+                                                                            "rawText": "foo",
+                                                                            "flags": 96,
+                                                                            "start": 48,
+                                                                            "end": 52
+                                                                        },
+                                                                        "typeParameters": null,
+                                                                        "flags": 0,
+                                                                        "start": 48,
+                                                                        "end": 52
+                                                                    }
+                                                                ],
+                                                                "flags": 0,
+                                                                "start": 46,
+                                                                "end": 52
+                                                            },
+                                                            {
+                                                                "kind": 144,
+                                                                "id": {
+                                                                    "kind": 134299649,
+                                                                    "text": "bar",
+                                                                    "rawText": "bar",
+                                                                    "flags": 96,
+                                                                    "start": 54,
+                                                                    "end": 58
+                                                                },
+                                                                "typeParameters": null,
+                                                                "flags": 0,
+                                                                "start": 54,
+                                                                "end": 58
+                                                            }
+                                                        ],
+                                                        "flags": 0,
+                                                        "start": 52,
+                                                        "end": 58
+                                                    },
+                                                    "flags": 0,
+                                                    "start": 33,
+                                                    "end": 58
+                                                }
+                                            ],
+                                            "trailingComma": false,
+                                            "flags": 32,
+                                            "start": 33,
+                                            "end": 58
+                                        },
+                                        "returnType": {
+                                            "kind": 144,
+                                            "id": {
+                                                "kind": 134299649,
+                                                "text": "T",
+                                                "rawText": "T",
+                                                "flags": 96,
+                                                "start": 62,
+                                                "end": 64
+                                            },
+                                            "typeParameters": null,
+                                            "flags": 0,
+                                            "start": 62,
+                                            "end": 64
+                                        },
+                                        "typeParameters": null,
+                                        "flags": 0,
+                                        "start": 31,
+                                        "end": 64
+                                    }
+                                ],
+                                "flags": 0,
+                                "start": 29,
+                                "end": 64
+                            },
+                            "flags": 0,
+                            "start": 10,
+                            "end": 64
+                        }
+                    ],
+                    "trailingComma": false,
+                    "flags": 32,
+                    "start": 10,
+                    "end": 64
+                },
+                "returnType": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 134299649,
+                        "text": "T",
+                        "rawText": "T",
+                        "flags": 96,
+                        "start": 68,
+                        "end": 70
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 68,
+                    "end": 70
+                },
+                "typeParameters": null,
+                "flags": 0,
+                "start": 8,
+                "end": 70
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 71
+        }
+    ],
+    "isModule": false,
+    "source": "type a = (...x?: string & foo | (...x?: string & foo | bar) => T) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 71
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type44.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type44.md
@@ -3,7 +3,7 @@
 ## Input
 
 `````js
-type a = (1) => T;
+type a = (...x) => T;
 `````
 
 ## Options
@@ -46,24 +46,46 @@ type a = (1) => T;
                 "arrowToken": {
                     "kind": 10,
                     "flags": 64,
-                    "start": 12,
-                    "end": 15
+                    "start": 15,
+                    "end": 18
                 },
                 "parameters": {
-                    "kind": 279,
+                    "kind": 208,
                     "parameters": [
                         {
-                            "kind": 134217968,
-                            "value": 1,
+                            "kind": 149,
+                            "ellipsisToken": {
+                                "kind": 524302,
+                                "flags": 64,
+                                "start": 10,
+                                "end": 13
+                            },
+                            "name": null,
+                            "optionalToken": null,
+                            "types": {
+                                "kind": 144,
+                                "id": {
+                                    "kind": 134299649,
+                                    "text": "x",
+                                    "rawText": "x",
+                                    "flags": 96,
+                                    "start": 13,
+                                    "end": 14
+                                },
+                                "typeParameters": null,
+                                "flags": 0,
+                                "start": 13,
+                                "end": 14
+                            },
                             "flags": 0,
                             "start": 10,
-                            "end": 11
+                            "end": 14
                         }
                     ],
                     "trailingComma": false,
                     "flags": 32,
-                    "start": 8,
-                    "end": 15
+                    "start": 10,
+                    "end": 14
                 },
                 "returnType": {
                     "kind": 144,
@@ -72,30 +94,30 @@ type a = (1) => T;
                         "text": "T",
                         "rawText": "T",
                         "flags": 96,
-                        "start": 15,
-                        "end": 17
+                        "start": 18,
+                        "end": 20
                     },
                     "typeParameters": null,
                     "flags": 0,
-                    "start": 15,
-                    "end": 17
+                    "start": 18,
+                    "end": 20
                 },
                 "typeParameters": null,
                 "flags": 0,
                 "start": 8,
-                "end": 17
+                "end": 20
             },
             "flags": 16,
             "start": 0,
-            "end": 18
+            "end": 21
         }
     ],
     "isModule": false,
-    "source": "type a = (1) => T;",
+    "source": "type a = (...x) => T;",
     "fileName": "__root__",
     "flags": 0,
     "start": 0,
-    "end": 18
+    "end": 21
 }
 ```
 

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type45.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type45.md
@@ -1,0 +1,298 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (a[a & b[a|b|c|d|e]][c][-1][][]) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 261,
+                "arrowToken": {
+                    "kind": 10,
+                    "flags": 64,
+                    "start": 41,
+                    "end": 44
+                },
+                "parameters": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 136,
+                        "type": {
+                            "kind": 136,
+                            "type": {
+                                "kind": 268,
+                                "objectType": {
+                                    "kind": 268,
+                                    "objectType": {
+                                        "kind": 268,
+                                        "objectType": {
+                                            "kind": 134299649,
+                                            "text": "a",
+                                            "rawText": "a",
+                                            "flags": 96,
+                                            "start": 10,
+                                            "end": 11
+                                        },
+                                        "indexType": {
+                                            "kind": 138,
+                                            "types": [
+                                                {
+                                                    "kind": 144,
+                                                    "id": {
+                                                        "kind": 134299649,
+                                                        "text": "a",
+                                                        "rawText": "a",
+                                                        "flags": 96,
+                                                        "start": 12,
+                                                        "end": 13
+                                                    },
+                                                    "typeParameters": null,
+                                                    "flags": 0,
+                                                    "start": 12,
+                                                    "end": 13
+                                                },
+                                                {
+                                                    "kind": 268,
+                                                    "objectType": {
+                                                        "kind": 144,
+                                                        "id": {
+                                                            "kind": 134299649,
+                                                            "text": "b",
+                                                            "rawText": "b",
+                                                            "flags": 96,
+                                                            "start": 15,
+                                                            "end": 17
+                                                        },
+                                                        "typeParameters": null,
+                                                        "flags": 0,
+                                                        "start": 15,
+                                                        "end": 17
+                                                    },
+                                                    "indexType": {
+                                                        "kind": 137,
+                                                        "types": [
+                                                            {
+                                                                "kind": 144,
+                                                                "id": {
+                                                                    "kind": 134299649,
+                                                                    "text": "a",
+                                                                    "rawText": "a",
+                                                                    "flags": 96,
+                                                                    "start": 18,
+                                                                    "end": 19
+                                                                },
+                                                                "typeParameters": null,
+                                                                "flags": 0,
+                                                                "start": 18,
+                                                                "end": 19
+                                                            },
+                                                            {
+                                                                "kind": 144,
+                                                                "id": {
+                                                                    "kind": 134299649,
+                                                                    "text": "b",
+                                                                    "rawText": "b",
+                                                                    "flags": 96,
+                                                                    "start": 20,
+                                                                    "end": 21
+                                                                },
+                                                                "typeParameters": null,
+                                                                "flags": 0,
+                                                                "start": 20,
+                                                                "end": 21
+                                                            },
+                                                            {
+                                                                "kind": 144,
+                                                                "id": {
+                                                                    "kind": 134299649,
+                                                                    "text": "c",
+                                                                    "rawText": "c",
+                                                                    "flags": 96,
+                                                                    "start": 22,
+                                                                    "end": 23
+                                                                },
+                                                                "typeParameters": null,
+                                                                "flags": 0,
+                                                                "start": 22,
+                                                                "end": 23
+                                                            },
+                                                            {
+                                                                "kind": 144,
+                                                                "id": {
+                                                                    "kind": 134299649,
+                                                                    "text": "d",
+                                                                    "rawText": "d",
+                                                                    "flags": 96,
+                                                                    "start": 24,
+                                                                    "end": 25
+                                                                },
+                                                                "typeParameters": null,
+                                                                "flags": 0,
+                                                                "start": 24,
+                                                                "end": 25
+                                                            },
+                                                            {
+                                                                "kind": 144,
+                                                                "id": {
+                                                                    "kind": 134299649,
+                                                                    "text": "e",
+                                                                    "rawText": "e",
+                                                                    "flags": 96,
+                                                                    "start": 26,
+                                                                    "end": 27
+                                                                },
+                                                                "typeParameters": null,
+                                                                "flags": 0,
+                                                                "start": 26,
+                                                                "end": 27
+                                                            }
+                                                        ],
+                                                        "flags": 0,
+                                                        "start": 19,
+                                                        "end": 27
+                                                    },
+                                                    "flags": 0,
+                                                    "start": 18,
+                                                    "end": 29
+                                                }
+                                            ],
+                                            "flags": 0,
+                                            "start": 13,
+                                            "end": 28
+                                        },
+                                        "flags": 0,
+                                        "start": 12,
+                                        "end": 30
+                                    },
+                                    "indexType": {
+                                        "kind": 144,
+                                        "id": {
+                                            "kind": 134299649,
+                                            "text": "c",
+                                            "rawText": "c",
+                                            "flags": 96,
+                                            "start": 30,
+                                            "end": 31
+                                        },
+                                        "typeParameters": null,
+                                        "flags": 0,
+                                        "start": 30,
+                                        "end": 31
+                                    },
+                                    "flags": 0,
+                                    "start": 30,
+                                    "end": 33
+                                },
+                                "indexType": {
+                                    "kind": 271,
+                                    "subtractionToken": {
+                                        "kind": 134318643,
+                                        "flags": 64,
+                                        "start": 33,
+                                        "end": 34
+                                    },
+                                    "value": 1,
+                                    "flags": 64,
+                                    "start": 33,
+                                    "end": 35
+                                },
+                                "flags": 0,
+                                "start": 33,
+                                "end": 37
+                            },
+                            "flags": 0,
+                            "start": 37,
+                            "end": 38
+                        },
+                        "flags": 0,
+                        "start": 39,
+                        "end": 40
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 8,
+                    "end": 40
+                },
+                "returnType": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 134299649,
+                        "text": "T",
+                        "rawText": "T",
+                        "flags": 96,
+                        "start": 44,
+                        "end": 46
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 44,
+                    "end": 46
+                },
+                "typeParameters": null,
+                "flags": 0,
+                "start": 8,
+                "end": 46
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 47
+        }
+    ],
+    "isModule": false,
+    "source": "type a = (a[a & b[a|b|c|d|e]][c][-1][][]) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 47
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type46.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type46.md
@@ -1,0 +1,230 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (a[a & b[a]][c][-1][][]) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 261,
+                "arrowToken": {
+                    "kind": 10,
+                    "flags": 64,
+                    "start": 33,
+                    "end": 36
+                },
+                "parameters": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 136,
+                        "type": {
+                            "kind": 136,
+                            "type": {
+                                "kind": 268,
+                                "objectType": {
+                                    "kind": 268,
+                                    "objectType": {
+                                        "kind": 268,
+                                        "objectType": {
+                                            "kind": 134299649,
+                                            "text": "a",
+                                            "rawText": "a",
+                                            "flags": 96,
+                                            "start": 10,
+                                            "end": 11
+                                        },
+                                        "indexType": {
+                                            "kind": 138,
+                                            "types": [
+                                                {
+                                                    "kind": 144,
+                                                    "id": {
+                                                        "kind": 134299649,
+                                                        "text": "a",
+                                                        "rawText": "a",
+                                                        "flags": 96,
+                                                        "start": 12,
+                                                        "end": 13
+                                                    },
+                                                    "typeParameters": null,
+                                                    "flags": 0,
+                                                    "start": 12,
+                                                    "end": 13
+                                                },
+                                                {
+                                                    "kind": 268,
+                                                    "objectType": {
+                                                        "kind": 144,
+                                                        "id": {
+                                                            "kind": 134299649,
+                                                            "text": "b",
+                                                            "rawText": "b",
+                                                            "flags": 96,
+                                                            "start": 15,
+                                                            "end": 17
+                                                        },
+                                                        "typeParameters": null,
+                                                        "flags": 0,
+                                                        "start": 15,
+                                                        "end": 17
+                                                    },
+                                                    "indexType": {
+                                                        "kind": 144,
+                                                        "id": {
+                                                            "kind": 134299649,
+                                                            "text": "a",
+                                                            "rawText": "a",
+                                                            "flags": 96,
+                                                            "start": 18,
+                                                            "end": 19
+                                                        },
+                                                        "typeParameters": null,
+                                                        "flags": 0,
+                                                        "start": 18,
+                                                        "end": 19
+                                                    },
+                                                    "flags": 0,
+                                                    "start": 18,
+                                                    "end": 21
+                                                }
+                                            ],
+                                            "flags": 0,
+                                            "start": 13,
+                                            "end": 20
+                                        },
+                                        "flags": 0,
+                                        "start": 12,
+                                        "end": 22
+                                    },
+                                    "indexType": {
+                                        "kind": 144,
+                                        "id": {
+                                            "kind": 134299649,
+                                            "text": "c",
+                                            "rawText": "c",
+                                            "flags": 96,
+                                            "start": 22,
+                                            "end": 23
+                                        },
+                                        "typeParameters": null,
+                                        "flags": 0,
+                                        "start": 22,
+                                        "end": 23
+                                    },
+                                    "flags": 0,
+                                    "start": 22,
+                                    "end": 25
+                                },
+                                "indexType": {
+                                    "kind": 271,
+                                    "subtractionToken": {
+                                        "kind": 134318643,
+                                        "flags": 64,
+                                        "start": 25,
+                                        "end": 26
+                                    },
+                                    "value": 1,
+                                    "flags": 64,
+                                    "start": 25,
+                                    "end": 27
+                                },
+                                "flags": 0,
+                                "start": 25,
+                                "end": 29
+                            },
+                            "flags": 0,
+                            "start": 29,
+                            "end": 30
+                        },
+                        "flags": 0,
+                        "start": 31,
+                        "end": 32
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 8,
+                    "end": 32
+                },
+                "returnType": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 134299649,
+                        "text": "T",
+                        "rawText": "T",
+                        "flags": 96,
+                        "start": 36,
+                        "end": 38
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 36,
+                    "end": 38
+                },
+                "typeParameters": null,
+                "flags": 0,
+                "start": 8,
+                "end": 38
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 39
+        }
+    ],
+    "isModule": false,
+    "source": "type a = (a[a & b[a]][c][-1][][]) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 39
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type47.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type47.md
@@ -1,0 +1,165 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (a[b][-1][][]) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 261,
+                "arrowToken": {
+                    "kind": 10,
+                    "flags": 64,
+                    "start": 23,
+                    "end": 26
+                },
+                "parameters": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 136,
+                        "type": {
+                            "kind": 136,
+                            "type": {
+                                "kind": 268,
+                                "objectType": {
+                                    "kind": 268,
+                                    "objectType": {
+                                        "kind": 134299649,
+                                        "text": "a",
+                                        "rawText": "a",
+                                        "flags": 96,
+                                        "start": 10,
+                                        "end": 11
+                                    },
+                                    "indexType": {
+                                        "kind": 144,
+                                        "id": {
+                                            "kind": 134299649,
+                                            "text": "b",
+                                            "rawText": "b",
+                                            "flags": 96,
+                                            "start": 12,
+                                            "end": 13
+                                        },
+                                        "typeParameters": null,
+                                        "flags": 0,
+                                        "start": 12,
+                                        "end": 13
+                                    },
+                                    "flags": 0,
+                                    "start": 12,
+                                    "end": 15
+                                },
+                                "indexType": {
+                                    "kind": 271,
+                                    "subtractionToken": {
+                                        "kind": 134318643,
+                                        "flags": 64,
+                                        "start": 15,
+                                        "end": 16
+                                    },
+                                    "value": 1,
+                                    "flags": 64,
+                                    "start": 15,
+                                    "end": 17
+                                },
+                                "flags": 0,
+                                "start": 15,
+                                "end": 19
+                            },
+                            "flags": 0,
+                            "start": 19,
+                            "end": 20
+                        },
+                        "flags": 0,
+                        "start": 21,
+                        "end": 22
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 8,
+                    "end": 22
+                },
+                "returnType": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 134299649,
+                        "text": "T",
+                        "rawText": "T",
+                        "flags": 96,
+                        "start": 26,
+                        "end": 28
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 26,
+                    "end": 28
+                },
+                "typeParameters": null,
+                "flags": 0,
+                "start": 8,
+                "end": 28
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 29
+        }
+    ],
+    "isModule": false,
+    "source": "type a = (a[b][-1][][]) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 29
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type48.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type48.md
@@ -1,0 +1,140 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (a[b][]) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 261,
+                "arrowToken": {
+                    "kind": 10,
+                    "flags": 64,
+                    "start": 17,
+                    "end": 20
+                },
+                "parameters": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 136,
+                        "type": {
+                            "kind": 268,
+                            "objectType": {
+                                "kind": 134299649,
+                                "text": "a",
+                                "rawText": "a",
+                                "flags": 96,
+                                "start": 10,
+                                "end": 11
+                            },
+                            "indexType": {
+                                "kind": 144,
+                                "id": {
+                                    "kind": 134299649,
+                                    "text": "b",
+                                    "rawText": "b",
+                                    "flags": 96,
+                                    "start": 12,
+                                    "end": 13
+                                },
+                                "typeParameters": null,
+                                "flags": 0,
+                                "start": 12,
+                                "end": 13
+                            },
+                            "flags": 0,
+                            "start": 12,
+                            "end": 15
+                        },
+                        "flags": 0,
+                        "start": 15,
+                        "end": 16
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 8,
+                    "end": 16
+                },
+                "returnType": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 134299649,
+                        "text": "T",
+                        "rawText": "T",
+                        "flags": 96,
+                        "start": 20,
+                        "end": 22
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 20,
+                    "end": 22
+                },
+                "typeParameters": null,
+                "flags": 0,
+                "start": 8,
+                "end": 22
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 23
+        }
+    ],
+    "isModule": false,
+    "source": "type a = (a[b][]) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 23
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type49.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type49.md
@@ -1,0 +1,167 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (a[b][x][][]) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 261,
+                "arrowToken": {
+                    "kind": 10,
+                    "flags": 64,
+                    "start": 22,
+                    "end": 25
+                },
+                "parameters": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 136,
+                        "type": {
+                            "kind": 136,
+                            "type": {
+                                "kind": 268,
+                                "objectType": {
+                                    "kind": 268,
+                                    "objectType": {
+                                        "kind": 134299649,
+                                        "text": "a",
+                                        "rawText": "a",
+                                        "flags": 96,
+                                        "start": 10,
+                                        "end": 11
+                                    },
+                                    "indexType": {
+                                        "kind": 144,
+                                        "id": {
+                                            "kind": 134299649,
+                                            "text": "b",
+                                            "rawText": "b",
+                                            "flags": 96,
+                                            "start": 12,
+                                            "end": 13
+                                        },
+                                        "typeParameters": null,
+                                        "flags": 0,
+                                        "start": 12,
+                                        "end": 13
+                                    },
+                                    "flags": 0,
+                                    "start": 12,
+                                    "end": 15
+                                },
+                                "indexType": {
+                                    "kind": 144,
+                                    "id": {
+                                        "kind": 134299649,
+                                        "text": "x",
+                                        "rawText": "x",
+                                        "flags": 96,
+                                        "start": 15,
+                                        "end": 16
+                                    },
+                                    "typeParameters": null,
+                                    "flags": 0,
+                                    "start": 15,
+                                    "end": 16
+                                },
+                                "flags": 0,
+                                "start": 15,
+                                "end": 18
+                            },
+                            "flags": 0,
+                            "start": 18,
+                            "end": 19
+                        },
+                        "flags": 0,
+                        "start": 20,
+                        "end": 21
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 8,
+                    "end": 21
+                },
+                "returnType": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 134299649,
+                        "text": "T",
+                        "rawText": "T",
+                        "flags": 96,
+                        "start": 25,
+                        "end": 27
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 25,
+                    "end": 27
+                },
+                "typeParameters": null,
+                "flags": 0,
+                "start": 8,
+                "end": 27
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 28
+        }
+    ],
+    "isModule": false,
+    "source": "type a = (a[b][x][][]) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 28
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type50.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type50.md
@@ -1,0 +1,132 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (a[-1]) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 261,
+                "arrowToken": {
+                    "kind": 10,
+                    "flags": 64,
+                    "start": 16,
+                    "end": 19
+                },
+                "parameters": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 268,
+                        "objectType": {
+                            "kind": 134299649,
+                            "text": "a",
+                            "rawText": "a",
+                            "flags": 96,
+                            "start": 10,
+                            "end": 11
+                        },
+                        "indexType": {
+                            "kind": 271,
+                            "subtractionToken": {
+                                "kind": 134318643,
+                                "flags": 64,
+                                "start": 12,
+                                "end": 13
+                            },
+                            "value": 1,
+                            "flags": 64,
+                            "start": 12,
+                            "end": 14
+                        },
+                        "flags": 0,
+                        "start": 12,
+                        "end": 16
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 8,
+                    "end": 15
+                },
+                "returnType": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 134299649,
+                        "text": "T",
+                        "rawText": "T",
+                        "flags": 96,
+                        "start": 19,
+                        "end": 21
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 19,
+                    "end": 21
+                },
+                "typeParameters": null,
+                "flags": 0,
+                "start": 8,
+                "end": 21
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 22
+        }
+    ],
+    "isModule": false,
+    "source": "type a = (a[-1]) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 22
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type51.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type51.md
@@ -1,0 +1,129 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = ([-1]) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 261,
+                "arrowToken": {
+                    "kind": 10,
+                    "flags": 64,
+                    "start": 15,
+                    "end": 18
+                },
+                "parameters": {
+                    "kind": 279,
+                    "parameters": [
+                        {
+                            "kind": 147,
+                            "elementTypes": [
+                                {
+                                    "kind": 271,
+                                    "subtractionToken": {
+                                        "kind": 134318643,
+                                        "flags": 64,
+                                        "start": 11,
+                                        "end": 12
+                                    },
+                                    "value": 1,
+                                    "flags": 64,
+                                    "start": 11,
+                                    "end": 13
+                                }
+                            ],
+                            "trailingComma": false,
+                            "flags": 0,
+                            "start": 10,
+                            "end": 14
+                        }
+                    ],
+                    "trailingComma": false,
+                    "flags": 32,
+                    "start": 8,
+                    "end": 18
+                },
+                "returnType": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 134299649,
+                        "text": "T",
+                        "rawText": "T",
+                        "flags": 96,
+                        "start": 18,
+                        "end": 20
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 18,
+                    "end": 20
+                },
+                "typeParameters": null,
+                "flags": 0,
+                "start": 8,
+                "end": 20
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 21
+        }
+    ],
+    "isModule": false,
+    "source": "type a = ([-1]) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 21
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type52.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type52.md
@@ -1,0 +1,123 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (["string"]) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 261,
+                "arrowToken": {
+                    "kind": 10,
+                    "flags": 64,
+                    "start": 21,
+                    "end": 24
+                },
+                "parameters": {
+                    "kind": 279,
+                    "parameters": [
+                        {
+                            "kind": 147,
+                            "elementTypes": [
+                                {
+                                    "kind": 134217967,
+                                    "value": "string",
+                                    "flags": 0,
+                                    "start": 11,
+                                    "end": 19
+                                }
+                            ],
+                            "trailingComma": false,
+                            "flags": 0,
+                            "start": 10,
+                            "end": 20
+                        }
+                    ],
+                    "trailingComma": false,
+                    "flags": 32,
+                    "start": 8,
+                    "end": 24
+                },
+                "returnType": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 134299649,
+                        "text": "T",
+                        "rawText": "T",
+                        "flags": 96,
+                        "start": 24,
+                        "end": 26
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 24,
+                    "end": 26
+                },
+                "typeParameters": null,
+                "flags": 0,
+                "start": 8,
+                "end": 26
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 27
+        }
+    ],
+    "isModule": false,
+    "source": "type a = ([\"string\"]) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 27
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/arrow-function-type53.md
+++ b/test/__snapshot__/parser/declarations/type/arrow-function-type53.md
@@ -1,0 +1,199 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (a[a & b[a]][c]) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 261,
+                "arrowToken": {
+                    "kind": 10,
+                    "flags": 64,
+                    "start": 25,
+                    "end": 28
+                },
+                "parameters": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 268,
+                        "objectType": {
+                            "kind": 268,
+                            "objectType": {
+                                "kind": 134299649,
+                                "text": "a",
+                                "rawText": "a",
+                                "flags": 96,
+                                "start": 10,
+                                "end": 11
+                            },
+                            "indexType": {
+                                "kind": 138,
+                                "types": [
+                                    {
+                                        "kind": 144,
+                                        "id": {
+                                            "kind": 134299649,
+                                            "text": "a",
+                                            "rawText": "a",
+                                            "flags": 96,
+                                            "start": 12,
+                                            "end": 13
+                                        },
+                                        "typeParameters": null,
+                                        "flags": 0,
+                                        "start": 12,
+                                        "end": 13
+                                    },
+                                    {
+                                        "kind": 268,
+                                        "objectType": {
+                                            "kind": 144,
+                                            "id": {
+                                                "kind": 134299649,
+                                                "text": "b",
+                                                "rawText": "b",
+                                                "flags": 96,
+                                                "start": 15,
+                                                "end": 17
+                                            },
+                                            "typeParameters": null,
+                                            "flags": 0,
+                                            "start": 15,
+                                            "end": 17
+                                        },
+                                        "indexType": {
+                                            "kind": 144,
+                                            "id": {
+                                                "kind": 134299649,
+                                                "text": "a",
+                                                "rawText": "a",
+                                                "flags": 96,
+                                                "start": 18,
+                                                "end": 19
+                                            },
+                                            "typeParameters": null,
+                                            "flags": 0,
+                                            "start": 18,
+                                            "end": 19
+                                        },
+                                        "flags": 0,
+                                        "start": 18,
+                                        "end": 21
+                                    }
+                                ],
+                                "flags": 0,
+                                "start": 13,
+                                "end": 20
+                            },
+                            "flags": 0,
+                            "start": 12,
+                            "end": 22
+                        },
+                        "indexType": {
+                            "kind": 144,
+                            "id": {
+                                "kind": 134299649,
+                                "text": "c",
+                                "rawText": "c",
+                                "flags": 96,
+                                "start": 22,
+                                "end": 23
+                            },
+                            "typeParameters": null,
+                            "flags": 0,
+                            "start": 22,
+                            "end": 23
+                        },
+                        "flags": 0,
+                        "start": 22,
+                        "end": 25
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 8,
+                    "end": 24
+                },
+                "returnType": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 134299649,
+                        "text": "T",
+                        "rawText": "T",
+                        "flags": 96,
+                        "start": 28,
+                        "end": 30
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 28,
+                    "end": 30
+                },
+                "typeParameters": null,
+                "flags": 0,
+                "start": 8,
+                "end": 30
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 31
+        }
+    ],
+    "isModule": false,
+    "source": "type a = (a[a & b[a]][c]) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 31
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/invalid-arrow-function-type1.md
+++ b/test/__snapshot__/parser/declarations/type/invalid-arrow-function-type1.md
@@ -1,0 +1,497 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (a[a & b][c | d][{a():string}][][][(a[a & b][c | d][{a():string}][][][]) => T]) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 260,
+                "type": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 136,
+                        "type": {
+                            "kind": 136,
+                            "type": {
+                                "kind": 136,
+                                "type": {
+                                    "kind": 268,
+                                    "objectType": {
+                                        "kind": 268,
+                                        "objectType": {
+                                            "kind": 268,
+                                            "objectType": {
+                                                "kind": 134299649,
+                                                "text": "a",
+                                                "rawText": "a",
+                                                "flags": 96,
+                                                "start": 10,
+                                                "end": 11
+                                            },
+                                            "indexType": {
+                                                "kind": 138,
+                                                "types": [
+                                                    {
+                                                        "kind": 144,
+                                                        "id": {
+                                                            "kind": 134299649,
+                                                            "text": "a",
+                                                            "rawText": "a",
+                                                            "flags": 96,
+                                                            "start": 12,
+                                                            "end": 13
+                                                        },
+                                                        "typeParameters": null,
+                                                        "flags": 0,
+                                                        "start": 12,
+                                                        "end": 13
+                                                    },
+                                                    {
+                                                        "kind": 144,
+                                                        "id": {
+                                                            "kind": 134299649,
+                                                            "text": "b",
+                                                            "rawText": "b",
+                                                            "flags": 96,
+                                                            "start": 15,
+                                                            "end": 17
+                                                        },
+                                                        "typeParameters": null,
+                                                        "flags": 0,
+                                                        "start": 15,
+                                                        "end": 17
+                                                    }
+                                                ],
+                                                "flags": 0,
+                                                "start": 13,
+                                                "end": 17
+                                            },
+                                            "flags": 0,
+                                            "start": 12,
+                                            "end": 19
+                                        },
+                                        "indexType": {
+                                            "kind": 137,
+                                            "types": [
+                                                {
+                                                    "kind": 144,
+                                                    "id": {
+                                                        "kind": 134299649,
+                                                        "text": "c",
+                                                        "rawText": "c",
+                                                        "flags": 96,
+                                                        "start": 19,
+                                                        "end": 20
+                                                    },
+                                                    "typeParameters": null,
+                                                    "flags": 0,
+                                                    "start": 19,
+                                                    "end": 20
+                                                },
+                                                {
+                                                    "kind": 144,
+                                                    "id": {
+                                                        "kind": 134299649,
+                                                        "text": "d",
+                                                        "rawText": "d",
+                                                        "flags": 96,
+                                                        "start": 22,
+                                                        "end": 24
+                                                    },
+                                                    "typeParameters": null,
+                                                    "flags": 0,
+                                                    "start": 22,
+                                                    "end": 24
+                                                }
+                                            ],
+                                            "flags": 0,
+                                            "start": 20,
+                                            "end": 24
+                                        },
+                                        "flags": 0,
+                                        "start": 19,
+                                        "end": 26
+                                    },
+                                    "indexType": {
+                                        "kind": 134234353,
+                                        "properties": [
+                                            {
+                                                "kind": 193,
+                                                "protoKeyword": null,
+                                                "staticToken": null,
+                                                "getKeyword": null,
+                                                "setKeyword": null,
+                                                "key": {
+                                                    "kind": 134299649,
+                                                    "text": "a",
+                                                    "rawText": "a",
+                                                    "flags": 96,
+                                                    "start": 27,
+                                                    "end": 28
+                                                },
+                                                "optionalToken": null,
+                                                "value": {
+                                                    "kind": 148,
+                                                    "parameters": {
+                                                        "kind": 208,
+                                                        "parameters": [],
+                                                        "trailingComma": false,
+                                                        "flags": 32,
+                                                        "start": 29,
+                                                        "end": 29
+                                                    },
+                                                    "returnType": {
+                                                        "kind": 134234347,
+                                                        "flags": 64,
+                                                        "start": 31,
+                                                        "end": 37
+                                                    },
+                                                    "typeParameters": null,
+                                                    "flags": 0,
+                                                    "start": 28,
+                                                    "end": 37
+                                                },
+                                                "flags": 0,
+                                                "start": 27,
+                                                "end": 37
+                                            }
+                                        ],
+                                        "flags": 0,
+                                        "start": 26,
+                                        "end": 38
+                                    },
+                                    "flags": 0,
+                                    "start": 26,
+                                    "end": 40
+                                },
+                                "flags": 0,
+                                "start": 40,
+                                "end": 41
+                            },
+                            "flags": 0,
+                            "start": 42,
+                            "end": 43
+                        },
+                        "flags": 0,
+                        "start": 44,
+                        "end": 44
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 8,
+                    "end": 44
+                },
+                "flags": 0,
+                "start": 8,
+                "end": 44
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 44
+        },
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 121,
+                "expression": {
+                    "kind": 536871042,
+                    "member": {
+                        "kind": 536871042,
+                        "member": {
+                            "kind": 536871042,
+                            "member": {
+                                "kind": 536871042,
+                                "member": {
+                                    "kind": 536871042,
+                                    "member": {
+                                        "kind": 536871042,
+                                        "member": {
+                                            "kind": 134299649,
+                                            "text": "a",
+                                            "rawText": "a",
+                                            "flags": 96,
+                                            "start": 45,
+                                            "end": 46
+                                        },
+                                        "expression": {
+                                            "kind": 198,
+                                            "left": {
+                                                "kind": 134299649,
+                                                "text": "a",
+                                                "rawText": "a",
+                                                "flags": 96,
+                                                "start": 47,
+                                                "end": 48
+                                            },
+                                            "operatorToken": {
+                                                "kind": 134252103,
+                                                "flags": 64,
+                                                "start": 48,
+                                                "end": 50
+                                            },
+                                            "right": {
+                                                "kind": 134299649,
+                                                "text": "b",
+                                                "rawText": "b",
+                                                "flags": 96,
+                                                "start": 50,
+                                                "end": 52
+                                            },
+                                            "flags": 32,
+                                            "start": 47,
+                                            "end": 52
+                                        },
+                                        "flags": 32,
+                                        "start": 44,
+                                        "end": 53
+                                    },
+                                    "expression": {
+                                        "kind": 198,
+                                        "left": {
+                                            "kind": 134299649,
+                                            "text": "c",
+                                            "rawText": "c",
+                                            "flags": 96,
+                                            "start": 54,
+                                            "end": 55
+                                        },
+                                        "operatorToken": {
+                                            "kind": 134251592,
+                                            "flags": 64,
+                                            "start": 55,
+                                            "end": 57
+                                        },
+                                        "right": {
+                                            "kind": 134299649,
+                                            "text": "d",
+                                            "rawText": "d",
+                                            "flags": 96,
+                                            "start": 57,
+                                            "end": 59
+                                        },
+                                        "flags": 32,
+                                        "start": 54,
+                                        "end": 59
+                                    },
+                                    "flags": 32,
+                                    "start": 44,
+                                    "end": 60
+                                },
+                                "expression": {
+                                    "kind": 220,
+                                    "propertyList": {
+                                        "kind": 218,
+                                        "properties": [
+                                            {
+                                                "kind": 257,
+                                                "asyncKeyword": null,
+                                                "generatorToken": null,
+                                                "getKeyword": null,
+                                                "setKeyword": null,
+                                                "method": {
+                                                    "kind": 209,
+                                                    "name": {
+                                                        "kind": 134299649,
+                                                        "text": "a",
+                                                        "rawText": "a",
+                                                        "flags": 96,
+                                                        "start": 62,
+                                                        "end": 63
+                                                    },
+                                                    "typeParameters": null,
+                                                    "formalParameters": {
+                                                        "kind": 214,
+                                                        "formalParameterList": [],
+                                                        "trailingComma": false,
+                                                        "flags": 32,
+                                                        "start": 64,
+                                                        "end": 65
+                                                    },
+                                                    "returnType": {
+                                                        "kind": 139,
+                                                        "type": {
+                                                            "kind": 134234347,
+                                                            "flags": 64,
+                                                            "start": 66,
+                                                            "end": 72
+                                                        },
+                                                        "flags": 0,
+                                                        "start": 65,
+                                                        "end": 72
+                                                    },
+                                                    "contents": {
+                                                        "kind": 216,
+                                                        "functionStatementList": {
+                                                            "kind": 217,
+                                                            "directives": [],
+                                                            "statements": [],
+                                                            "flags": 32,
+                                                            "start": 72,
+                                                            "end": 72
+                                                        },
+                                                        "flags": 32,
+                                                        "start": 72,
+                                                        "end": 72
+                                                    },
+                                                    "flags": 32,
+                                                    "start": 63,
+                                                    "end": 72
+                                                },
+                                                "flags": 32,
+                                                "start": 62,
+                                                "end": 72
+                                            }
+                                        ],
+                                        "trailingComma": false,
+                                        "flags": 16,
+                                        "start": 62,
+                                        "end": 72
+                                    },
+                                    "flags": 48,
+                                    "start": 61,
+                                    "end": 73
+                                },
+                                "flags": 32,
+                                "start": 44,
+                                "end": 74
+                            },
+                            "expression": {
+                                "kind": 16637,
+                                "text": "",
+                                "flags": 64,
+                                "start": 75,
+                                "end": 75
+                            },
+                            "flags": 32,
+                            "start": 44,
+                            "end": 76
+                        },
+                        "expression": {
+                            "kind": 16637,
+                            "text": "",
+                            "flags": 64,
+                            "start": 77,
+                            "end": 77
+                        },
+                        "flags": 32,
+                        "start": 44,
+                        "end": 78
+                    },
+                    "expression": {
+                        "kind": 16637,
+                        "text": "",
+                        "flags": 64,
+                        "start": 79,
+                        "end": 79
+                    },
+                    "flags": 32,
+                    "start": 44,
+                    "end": 80
+                },
+                "flags": 32,
+                "start": 44,
+                "end": 81
+            },
+            "flags": 16,
+            "start": 44,
+            "end": 81
+        },
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 134299649,
+                "text": "T",
+                "rawText": "T",
+                "flags": 96,
+                "start": 84,
+                "end": 86
+            },
+            "flags": 16,
+            "start": 84,
+            "end": 86
+        },
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 134299649,
+                "text": "T",
+                "rawText": "T",
+                "flags": 96,
+                "start": 91,
+                "end": 93
+            },
+            "flags": 16,
+            "start": 91,
+            "end": 94
+        }
+    ],
+    "isModule": false,
+    "source": "type a = (a[a & b][c | d][{a():string}][][][(a[a & b][c | d][{a():string}][][][]) => T]) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 94
+}
+```
+
+### Printed
+
+```javascript
+
+```
+
+### Diagnostics
+
+```javascript
+✖ Type expected - start: 44, end: 45
+✖ Missing an opening brace - '{ - start: 72, end: 73
+✖ An member access expression should take an argument. - start: 44, end: 76
+✖ Identifier expected - start: 75, end: 76
+✖ An member access expression should take an argument. - start: 44, end: 78
+✖ Identifier expected - start: 77, end: 78
+✖ An member access expression should take an argument. - start: 44, end: 80
+✖ Identifier expected - start: 79, end: 80
+✖ Expected a `;` - start: 81, end: 84
+✖ Expected a `;` - start: 86, end: 87
+✖ Declaration or statement expected - start: 87, end: 88
+✖ Declaration or statement expected - start: 88, end: 91
+
+```
+

--- a/test/__snapshot__/parser/declarations/type/invalid-arrow-function-type2.md
+++ b/test/__snapshot__/parser/declarations/type/invalid-arrow-function-type2.md
@@ -1,0 +1,291 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (a[a & b][c | d][(x) => T][][][]) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 260,
+                "type": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 136,
+                        "type": {
+                            "kind": 268,
+                            "objectType": {
+                                "kind": 268,
+                                "objectType": {
+                                    "kind": 134299649,
+                                    "text": "a",
+                                    "rawText": "a",
+                                    "flags": 96,
+                                    "start": 10,
+                                    "end": 11
+                                },
+                                "indexType": {
+                                    "kind": 138,
+                                    "types": [
+                                        {
+                                            "kind": 144,
+                                            "id": {
+                                                "kind": 134299649,
+                                                "text": "a",
+                                                "rawText": "a",
+                                                "flags": 96,
+                                                "start": 12,
+                                                "end": 13
+                                            },
+                                            "typeParameters": null,
+                                            "flags": 0,
+                                            "start": 12,
+                                            "end": 13
+                                        },
+                                        {
+                                            "kind": 144,
+                                            "id": {
+                                                "kind": 134299649,
+                                                "text": "b",
+                                                "rawText": "b",
+                                                "flags": 96,
+                                                "start": 15,
+                                                "end": 17
+                                            },
+                                            "typeParameters": null,
+                                            "flags": 0,
+                                            "start": 15,
+                                            "end": 17
+                                        }
+                                    ],
+                                    "flags": 0,
+                                    "start": 13,
+                                    "end": 17
+                                },
+                                "flags": 0,
+                                "start": 12,
+                                "end": 19
+                            },
+                            "indexType": {
+                                "kind": 137,
+                                "types": [
+                                    {
+                                        "kind": 144,
+                                        "id": {
+                                            "kind": 134299649,
+                                            "text": "c",
+                                            "rawText": "c",
+                                            "flags": 96,
+                                            "start": 19,
+                                            "end": 20
+                                        },
+                                        "typeParameters": null,
+                                        "flags": 0,
+                                        "start": 19,
+                                        "end": 20
+                                    },
+                                    {
+                                        "kind": 144,
+                                        "id": {
+                                            "kind": 134299649,
+                                            "text": "d",
+                                            "rawText": "d",
+                                            "flags": 96,
+                                            "start": 22,
+                                            "end": 24
+                                        },
+                                        "typeParameters": null,
+                                        "flags": 0,
+                                        "start": 22,
+                                        "end": 24
+                                    }
+                                ],
+                                "flags": 0,
+                                "start": 20,
+                                "end": 24
+                            },
+                            "flags": 0,
+                            "start": 19,
+                            "end": 26
+                        },
+                        "flags": 0,
+                        "start": 26,
+                        "end": 26
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 8,
+                    "end": 26
+                },
+                "flags": 0,
+                "start": 8,
+                "end": 26
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 26
+        },
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 271,
+                "arrowToken": {
+                    "kind": 10,
+                    "flags": 64,
+                    "start": 29,
+                    "end": 32
+                },
+                "typeParameters": null,
+                "parameters": [
+                    {
+                        "kind": 134299649,
+                        "text": "x",
+                        "rawText": "x",
+                        "flags": 96,
+                        "start": 27,
+                        "end": 28
+                    }
+                ],
+                "asyncKeyword": null,
+                "returnType": null,
+                "contents": {
+                    "kind": 134299649,
+                    "text": "T",
+                    "rawText": "T",
+                    "flags": 96,
+                    "start": 32,
+                    "end": 34
+                },
+                "flags": 32,
+                "start": 26,
+                "end": 34
+            },
+            "flags": 16,
+            "start": 26,
+            "end": 34
+        },
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 536871042,
+                "member": {
+                    "kind": 536871042,
+                    "member": {
+                        "kind": 119,
+                        "elementList": {
+                            "kind": 270,
+                            "elements": [],
+                            "trailingComma": false,
+                            "flags": 32,
+                            "start": 36,
+                            "end": 36
+                        },
+                        "flags": 32,
+                        "start": 35,
+                        "end": 37
+                    },
+                    "expression": {
+                        "kind": 16637,
+                        "text": "",
+                        "flags": 64,
+                        "start": 38,
+                        "end": 38
+                    },
+                    "flags": 32,
+                    "start": 35,
+                    "end": 39
+                },
+                "expression": {
+                    "kind": 16637,
+                    "text": "",
+                    "flags": 64,
+                    "start": 40,
+                    "end": 40
+                },
+                "flags": 32,
+                "start": 35,
+                "end": 41
+            },
+            "flags": 16,
+            "start": 35,
+            "end": 41
+        },
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 134299649,
+                "text": "T",
+                "rawText": "T",
+                "flags": 96,
+                "start": 45,
+                "end": 47
+            },
+            "flags": 16,
+            "start": 45,
+            "end": 48
+        }
+    ],
+    "isModule": false,
+    "source": "type a = (a[a & b][c | d][(x) => T][][][]) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 48
+}
+```
+
+### Printed
+
+```javascript
+
+```
+
+### Diagnostics
+
+```javascript
+✖ Type expected - start: 26, end: 27
+✖ Expected a `;` - start: 34, end: 35
+✖ An member access expression should take an argument. - start: 35, end: 39
+✖ Identifier expected - start: 38, end: 39
+✖ An member access expression should take an argument. - start: 35, end: 41
+✖ Identifier expected - start: 40, end: 41
+✖ Expected a `;` - start: 41, end: 42
+✖ Declaration or statement expected - start: 42, end: 45
+
+```
+

--- a/test/__snapshot__/parser/declarations/type/invalid-arrow-function-type3.md
+++ b/test/__snapshot__/parser/declarations/type/invalid-arrow-function-type3.md
@@ -1,0 +1,297 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (a[a & b[]][c | d][(x) => T][][][]) => T;
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 260,
+                "type": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 136,
+                        "type": {
+                            "kind": 268,
+                            "objectType": {
+                                "kind": 268,
+                                "objectType": {
+                                    "kind": 134299649,
+                                    "text": "a",
+                                    "rawText": "a",
+                                    "flags": 96,
+                                    "start": 10,
+                                    "end": 11
+                                },
+                                "indexType": {
+                                    "kind": 138,
+                                    "types": [
+                                        {
+                                            "kind": 144,
+                                            "id": {
+                                                "kind": 134299649,
+                                                "text": "a",
+                                                "rawText": "a",
+                                                "flags": 96,
+                                                "start": 12,
+                                                "end": 13
+                                            },
+                                            "typeParameters": null,
+                                            "flags": 0,
+                                            "start": 12,
+                                            "end": 13
+                                        },
+                                        {
+                                            "kind": 136,
+                                            "type": {
+                                                "kind": 144,
+                                                "id": {
+                                                    "kind": 134299649,
+                                                    "text": "b",
+                                                    "rawText": "b",
+                                                    "flags": 96,
+                                                    "start": 15,
+                                                    "end": 17
+                                                },
+                                                "typeParameters": null,
+                                                "flags": 0,
+                                                "start": 15,
+                                                "end": 17
+                                            },
+                                            "flags": 0,
+                                            "start": 18,
+                                            "end": 19
+                                        }
+                                    ],
+                                    "flags": 0,
+                                    "start": 13,
+                                    "end": 19
+                                },
+                                "flags": 0,
+                                "start": 12,
+                                "end": 21
+                            },
+                            "indexType": {
+                                "kind": 137,
+                                "types": [
+                                    {
+                                        "kind": 144,
+                                        "id": {
+                                            "kind": 134299649,
+                                            "text": "c",
+                                            "rawText": "c",
+                                            "flags": 96,
+                                            "start": 21,
+                                            "end": 22
+                                        },
+                                        "typeParameters": null,
+                                        "flags": 0,
+                                        "start": 21,
+                                        "end": 22
+                                    },
+                                    {
+                                        "kind": 144,
+                                        "id": {
+                                            "kind": 134299649,
+                                            "text": "d",
+                                            "rawText": "d",
+                                            "flags": 96,
+                                            "start": 24,
+                                            "end": 26
+                                        },
+                                        "typeParameters": null,
+                                        "flags": 0,
+                                        "start": 24,
+                                        "end": 26
+                                    }
+                                ],
+                                "flags": 0,
+                                "start": 22,
+                                "end": 26
+                            },
+                            "flags": 0,
+                            "start": 21,
+                            "end": 28
+                        },
+                        "flags": 0,
+                        "start": 28,
+                        "end": 28
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 8,
+                    "end": 28
+                },
+                "flags": 0,
+                "start": 8,
+                "end": 28
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 28
+        },
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 271,
+                "arrowToken": {
+                    "kind": 10,
+                    "flags": 64,
+                    "start": 31,
+                    "end": 34
+                },
+                "typeParameters": null,
+                "parameters": [
+                    {
+                        "kind": 134299649,
+                        "text": "x",
+                        "rawText": "x",
+                        "flags": 96,
+                        "start": 29,
+                        "end": 30
+                    }
+                ],
+                "asyncKeyword": null,
+                "returnType": null,
+                "contents": {
+                    "kind": 134299649,
+                    "text": "T",
+                    "rawText": "T",
+                    "flags": 96,
+                    "start": 34,
+                    "end": 36
+                },
+                "flags": 32,
+                "start": 28,
+                "end": 36
+            },
+            "flags": 16,
+            "start": 28,
+            "end": 36
+        },
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 536871042,
+                "member": {
+                    "kind": 536871042,
+                    "member": {
+                        "kind": 119,
+                        "elementList": {
+                            "kind": 270,
+                            "elements": [],
+                            "trailingComma": false,
+                            "flags": 32,
+                            "start": 38,
+                            "end": 38
+                        },
+                        "flags": 32,
+                        "start": 37,
+                        "end": 39
+                    },
+                    "expression": {
+                        "kind": 16637,
+                        "text": "",
+                        "flags": 64,
+                        "start": 40,
+                        "end": 40
+                    },
+                    "flags": 32,
+                    "start": 37,
+                    "end": 41
+                },
+                "expression": {
+                    "kind": 16637,
+                    "text": "",
+                    "flags": 64,
+                    "start": 42,
+                    "end": 42
+                },
+                "flags": 32,
+                "start": 37,
+                "end": 43
+            },
+            "flags": 16,
+            "start": 37,
+            "end": 43
+        },
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 134299649,
+                "text": "T",
+                "rawText": "T",
+                "flags": 96,
+                "start": 47,
+                "end": 49
+            },
+            "flags": 16,
+            "start": 47,
+            "end": 50
+        }
+    ],
+    "isModule": false,
+    "source": "type a = (a[a & b[]][c | d][(x) => T][][][]) => T;",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 50
+}
+```
+
+### Printed
+
+```javascript
+
+```
+
+### Diagnostics
+
+```javascript
+✖ Type expected - start: 28, end: 29
+✖ Expected a `;` - start: 36, end: 37
+✖ An member access expression should take an argument. - start: 37, end: 41
+✖ Identifier expected - start: 40, end: 41
+✖ An member access expression should take an argument. - start: 37, end: 43
+✖ Identifier expected - start: 42, end: 43
+✖ Expected a `;` - start: 43, end: 44
+✖ Declaration or statement expected - start: 44, end: 47
+
+```
+

--- a/test/__snapshot__/parser/declarations/type/invalid-arrow-function-type4.md
+++ b/test/__snapshot__/parser/declarations/type/invalid-arrow-function-type4.md
@@ -3,7 +3,7 @@
 ## Input
 
 `````js
-type a = (1) => T;
+type X = (x?: y) => T;
 `````
 
 ## Options
@@ -34,8 +34,8 @@ type a = (1) => T;
             },
             "name": {
                 "kind": 134299649,
-                "text": "a",
-                "rawText": "a",
+                "text": "X",
+                "rawText": "X",
                 "flags": 96,
                 "start": 4,
                 "end": 6
@@ -46,18 +46,47 @@ type a = (1) => T;
                 "arrowToken": {
                     "kind": 10,
                     "flags": 64,
-                    "start": 12,
-                    "end": 15
+                    "start": 16,
+                    "end": 19
                 },
                 "parameters": {
                     "kind": 279,
                     "parameters": [
                         {
-                            "kind": 134217968,
-                            "value": 1,
+                            "kind": 149,
+                            "ellipsisToken": null,
+                            "name": {
+                                "kind": 134299649,
+                                "text": "x",
+                                "rawText": "x",
+                                "flags": 96,
+                                "start": 10,
+                                "end": 11
+                            },
+                            "optionalToken": {
+                                "kind": 134217750,
+                                "flags": 64,
+                                "start": 11,
+                                "end": 12
+                            },
+                            "types": {
+                                "kind": 144,
+                                "id": {
+                                    "kind": 134299649,
+                                    "text": "y",
+                                    "rawText": "y",
+                                    "flags": 96,
+                                    "start": 13,
+                                    "end": 15
+                                },
+                                "typeParameters": null,
+                                "flags": 0,
+                                "start": 13,
+                                "end": 15
+                            },
                             "flags": 0,
-                            "start": 10,
-                            "end": 11
+                            "start": 8,
+                            "end": 15
                         }
                     ],
                     "trailingComma": false,
@@ -72,30 +101,30 @@ type a = (1) => T;
                         "text": "T",
                         "rawText": "T",
                         "flags": 96,
-                        "start": 15,
-                        "end": 17
+                        "start": 19,
+                        "end": 21
                     },
                     "typeParameters": null,
                     "flags": 0,
-                    "start": 15,
-                    "end": 17
+                    "start": 19,
+                    "end": 21
                 },
                 "typeParameters": null,
                 "flags": 0,
                 "start": 8,
-                "end": 17
+                "end": 21
             },
             "flags": 16,
             "start": 0,
-            "end": 18
+            "end": 22
         }
     ],
     "isModule": false,
-    "source": "type a = (1) => T;",
+    "source": "type X = (x?: y) => T;",
     "fileName": "__root__",
     "flags": 0,
     "start": 0,
-    "end": 18
+    "end": 22
 }
 ```
 

--- a/test/__snapshot__/parser/declarations/type/invalid-arrow-function-type4.md
+++ b/test/__snapshot__/parser/declarations/type/invalid-arrow-function-type4.md
@@ -3,7 +3,7 @@
 ## Input
 
 `````js
-type X = (x?: y) => T;
+type X = (x?) => T;
 `````
 
 ## Options
@@ -46,8 +46,8 @@ type X = (x?: y) => T;
                 "arrowToken": {
                     "kind": 10,
                     "flags": 64,
-                    "start": 16,
-                    "end": 19
+                    "start": 13,
+                    "end": 16
                 },
                 "parameters": {
                     "kind": 279,
@@ -69,30 +69,16 @@ type X = (x?: y) => T;
                                 "start": 11,
                                 "end": 12
                             },
-                            "types": {
-                                "kind": 144,
-                                "id": {
-                                    "kind": 134299649,
-                                    "text": "y",
-                                    "rawText": "y",
-                                    "flags": 96,
-                                    "start": 13,
-                                    "end": 15
-                                },
-                                "typeParameters": null,
-                                "flags": 0,
-                                "start": 13,
-                                "end": 15
-                            },
+                            "types": null,
                             "flags": 0,
                             "start": 8,
-                            "end": 15
+                            "end": 12
                         }
                     ],
                     "trailingComma": false,
                     "flags": 32,
                     "start": 8,
-                    "end": 15
+                    "end": 12
                 },
                 "returnType": {
                     "kind": 144,
@@ -101,30 +87,30 @@ type X = (x?: y) => T;
                         "text": "T",
                         "rawText": "T",
                         "flags": 96,
-                        "start": 19,
-                        "end": 21
+                        "start": 16,
+                        "end": 18
                     },
                     "typeParameters": null,
                     "flags": 0,
-                    "start": 19,
-                    "end": 21
+                    "start": 16,
+                    "end": 18
                 },
                 "typeParameters": null,
                 "flags": 0,
                 "start": 8,
-                "end": 21
+                "end": 18
             },
             "flags": 16,
             "start": 0,
-            "end": 22
+            "end": 19
         }
     ],
     "isModule": false,
-    "source": "type X = (x?: y) => T;",
+    "source": "type X = (x?) => T;",
     "fileName": "__root__",
     "flags": 0,
     "start": 0,
-    "end": 22
+    "end": 19
 }
 ```
 
@@ -132,12 +118,12 @@ type X = (x?: y) => T;
 
 ```javascript
 
-
 ```
 
 ### Diagnostics
 
 ```javascript
-✔ No errors
+✖ An optional parameter cannot be used without an ':' in an arrow function type parameter list - start: 12, end: 13
+
 ```
 

--- a/test/__snapshot__/parser/declarations/type/invalid-arrow-function-type5.md
+++ b/test/__snapshot__/parser/declarations/type/invalid-arrow-function-type5.md
@@ -1,0 +1,135 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type X = ((x?) => T);
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "X",
+                "rawText": "X",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 260,
+                "type": {
+                    "kind": 261,
+                    "arrowToken": {
+                        "kind": 10,
+                        "flags": 64,
+                        "start": 14,
+                        "end": 17
+                    },
+                    "parameters": {
+                        "kind": 279,
+                        "parameters": [
+                            {
+                                "kind": 149,
+                                "ellipsisToken": null,
+                                "name": {
+                                    "kind": 134299649,
+                                    "text": "x",
+                                    "rawText": "x",
+                                    "flags": 96,
+                                    "start": 11,
+                                    "end": 12
+                                },
+                                "optionalToken": {
+                                    "kind": 134217750,
+                                    "flags": 64,
+                                    "start": 12,
+                                    "end": 13
+                                },
+                                "types": null,
+                                "flags": 0,
+                                "start": 8,
+                                "end": 13
+                            }
+                        ],
+                        "trailingComma": false,
+                        "flags": 32,
+                        "start": 8,
+                        "end": 13
+                    },
+                    "returnType": {
+                        "kind": 144,
+                        "id": {
+                            "kind": 134299649,
+                            "text": "T",
+                            "rawText": "T",
+                            "flags": 96,
+                            "start": 17,
+                            "end": 19
+                        },
+                        "typeParameters": null,
+                        "flags": 0,
+                        "start": 17,
+                        "end": 19
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 8,
+                    "end": 19
+                },
+                "flags": 0,
+                "start": 8,
+                "end": 20
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 21
+        }
+    ],
+    "isModule": false,
+    "source": "type X = ((x?) => T);",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 21
+}
+```
+
+### Printed
+
+```javascript
+
+```
+
+### Diagnostics
+
+```javascript
+✖ An optional parameter cannot be used without an ':' in an arrow function type parameter list - start: 13, end: 14
+
+```
+

--- a/test/__snapshot__/parser/declarations/type/parenthesized-type17.md
+++ b/test/__snapshot__/parser/declarations/type/parenthesized-type17.md
@@ -1,0 +1,133 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (bj[c])[d];
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 268,
+                "objectType": {
+                    "kind": 260,
+                    "type": {
+                        "kind": 144,
+                        "id": {
+                            "kind": 268,
+                            "objectType": {
+                                "kind": 134299649,
+                                "text": "bj",
+                                "rawText": "bj",
+                                "flags": 96,
+                                "start": 10,
+                                "end": 12
+                            },
+                            "indexType": {
+                                "kind": 144,
+                                "id": {
+                                    "kind": 134299649,
+                                    "text": "c",
+                                    "rawText": "c",
+                                    "flags": 96,
+                                    "start": 13,
+                                    "end": 14
+                                },
+                                "typeParameters": null,
+                                "flags": 0,
+                                "start": 13,
+                                "end": 14
+                            },
+                            "flags": 0,
+                            "start": 13,
+                            "end": 16
+                        },
+                        "typeParameters": null,
+                        "flags": 0,
+                        "start": 8,
+                        "end": 15
+                    },
+                    "flags": 0,
+                    "start": 8,
+                    "end": 16
+                },
+                "indexType": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 134299649,
+                        "text": "d",
+                        "rawText": "d",
+                        "flags": 96,
+                        "start": 17,
+                        "end": 18
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 17,
+                    "end": 18
+                },
+                "flags": 0,
+                "start": 17,
+                "end": 20
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 20
+        }
+    ],
+    "isModule": false,
+    "source": "type a = (bj[c])[d];",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 20
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/parenthesized-type18.md
+++ b/test/__snapshot__/parser/declarations/type/parenthesized-type18.md
@@ -1,0 +1,112 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (bj[c])
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 260,
+                "type": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 268,
+                        "objectType": {
+                            "kind": 134299649,
+                            "text": "bj",
+                            "rawText": "bj",
+                            "flags": 96,
+                            "start": 10,
+                            "end": 12
+                        },
+                        "indexType": {
+                            "kind": 144,
+                            "id": {
+                                "kind": 134299649,
+                                "text": "c",
+                                "rawText": "c",
+                                "flags": 96,
+                                "start": 13,
+                                "end": 14
+                            },
+                            "typeParameters": null,
+                            "flags": 0,
+                            "start": 13,
+                            "end": 14
+                        },
+                        "flags": 0,
+                        "start": 13,
+                        "end": 16
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 8,
+                    "end": 15
+                },
+                "flags": 0,
+                "start": 8,
+                "end": 16
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 16
+        }
+    ],
+    "isModule": false,
+    "source": "type a = (bj[c])",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 16
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/parenthesized-type19.md
+++ b/test/__snapshot__/parser/declarations/type/parenthesized-type19.md
@@ -1,0 +1,110 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (a[-1]);
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 260,
+                "type": {
+                    "kind": 144,
+                    "id": {
+                        "kind": 268,
+                        "objectType": {
+                            "kind": 134299649,
+                            "text": "a",
+                            "rawText": "a",
+                            "flags": 96,
+                            "start": 10,
+                            "end": 11
+                        },
+                        "indexType": {
+                            "kind": 271,
+                            "subtractionToken": {
+                                "kind": 134318643,
+                                "flags": 64,
+                                "start": 12,
+                                "end": 13
+                            },
+                            "value": 1,
+                            "flags": 64,
+                            "start": 12,
+                            "end": 14
+                        },
+                        "flags": 0,
+                        "start": 12,
+                        "end": 16
+                    },
+                    "typeParameters": null,
+                    "flags": 0,
+                    "start": 8,
+                    "end": 15
+                },
+                "flags": 0,
+                "start": 8,
+                "end": 16
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 17
+        }
+    ],
+    "isModule": false,
+    "source": "type a = (a[-1]);",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 17
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/parenthesized-type20.md
+++ b/test/__snapshot__/parser/declarations/type/parenthesized-type20.md
@@ -1,0 +1,98 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = ([-1])
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 260,
+                "type": {
+                    "kind": 147,
+                    "elementTypes": [
+                        {
+                            "kind": 271,
+                            "subtractionToken": {
+                                "kind": 134318643,
+                                "flags": 64,
+                                "start": 11,
+                                "end": 12
+                            },
+                            "value": 1,
+                            "flags": 64,
+                            "start": 11,
+                            "end": 13
+                        }
+                    ],
+                    "trailingComma": false,
+                    "flags": 0,
+                    "start": 10,
+                    "end": 14
+                },
+                "flags": 0,
+                "start": 8,
+                "end": 15
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 15
+        }
+    ],
+    "isModule": false,
+    "source": "type a = ([-1])",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 15
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/parenthesized-type21.md
+++ b/test/__snapshot__/parser/declarations/type/parenthesized-type21.md
@@ -1,0 +1,90 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type a = (["string"]);
+`````
+
+## Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "a",
+                "rawText": "a",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 260,
+                "type": {
+                    "kind": 147,
+                    "elementTypes": [
+                        {
+                            "kind": 134217967,
+                            "value": "string",
+                            "flags": 0,
+                            "start": 11,
+                            "end": 19
+                        }
+                    ],
+                    "trailingComma": false,
+                    "flags": 0,
+                    "start": 10,
+                    "end": 20
+                },
+                "flags": 0,
+                "start": 8,
+                "end": 21
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 22
+        }
+    ],
+    "isModule": false,
+    "source": "type a = ([\"string\"]);",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 22
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/tuple-with-subtract.md
+++ b/test/__snapshot__/parser/declarations/type/tuple-with-subtract.md
@@ -1,0 +1,92 @@
+# Kataw parser test case
+
+## Input
+
+`````js
+type x = [-1];
+`````
+
+## Options
+
+### Parser Options
+
+`````js
+{ allowTypes : true }
+`````
+
+## Output
+
+### CST
+
+```javascript
+{
+    "kind": 122,
+    "directives": [],
+    "statements": [
+        {
+            "kind": 200,
+            "declareToken": null,
+            "typeToken": {
+                "kind": 24775,
+                "flags": 64,
+                "start": 0,
+                "end": 6
+            },
+            "name": {
+                "kind": 134299649,
+                "text": "x",
+                "rawText": "x",
+                "flags": 96,
+                "start": 4,
+                "end": 6
+            },
+            "typeParameters": null,
+            "type": {
+                "kind": 147,
+                "elementTypes": [
+                    {
+                        "kind": 271,
+                        "subtractionToken": {
+                            "kind": 134318643,
+                            "flags": 64,
+                            "start": 10,
+                            "end": 11
+                        },
+                        "value": 1,
+                        "flags": 64,
+                        "start": 10,
+                        "end": 12
+                    }
+                ],
+                "trailingComma": false,
+                "flags": 0,
+                "start": 8,
+                "end": 13
+            },
+            "flags": 16,
+            "start": 0,
+            "end": 14
+        }
+    ],
+    "isModule": false,
+    "source": "type x = [-1];",
+    "fileName": "__root__",
+    "flags": 0,
+    "start": 0,
+    "end": 14
+}
+```
+
+### Printed
+
+```javascript
+
+
+```
+
+### Diagnostics
+
+```javascript
+✔ No errors
+```
+

--- a/test/__snapshot__/parser/declarations/type/type-union.md
+++ b/test/__snapshot__/parser/declarations/type/type-union.md
@@ -171,141 +171,127 @@ type overloads2 = {
             },
             "typeParameters": null,
             "type": {
-                "kind": 260,
-                "type": {
-                    "kind": 144,
-                    "id": {
-                        "kind": 134299649,
-                        "text": "x",
-                        "rawText": "x",
-                        "flags": 96,
-                        "start": 69,
-                        "end": 70
-                    },
-                    "typeParameters": null,
-                    "flags": 0,
-                    "start": 69,
-                    "end": 70
-                },
-                "flags": 0,
-                "start": 66,
-                "end": 70
-            },
-            "flags": 17,
-            "start": 44,
-            "end": 70
-        },
-        {
-            "kind": 120,
-            "expression": {
-                "kind": 134299649,
-                "text": "string",
-                "rawText": "string",
-                "flags": 96,
-                "start": 71,
-                "end": 78
-            },
-            "flags": 16,
-            "start": 71,
-            "end": 78
-        },
-        {
-            "kind": 120,
-            "expression": {
-                "kind": 134299649,
-                "text": "number",
-                "rawText": "number",
-                "flags": 96,
-                "start": 82,
-                "end": 89
-            },
-            "flags": 16,
-            "start": 82,
-            "end": 89
-        },
-        {
-            "kind": 120,
-            "expression": {
-                "kind": 198,
-                "left": {
-                    "kind": 16637,
-                    "text": "",
-                    "flags": 64,
-                    "start": 90,
-                    "end": 90
-                },
-                "operatorToken": {
-                    "kind": 134252103,
-                    "flags": 65,
-                    "start": 90,
-                    "end": 94
-                },
-                "right": {
-                    "kind": 121,
-                    "expression": {
-                        "kind": 271,
-                        "arrowToken": {
-                            "kind": 10,
-                            "flags": 64,
-                            "start": 107,
-                            "end": 110
-                        },
-                        "typeParameters": null,
-                        "parameters": [
-                            {
-                                "kind": 281,
-                                "ellipsisToken": null,
-                                "left": {
-                                    "kind": 134299649,
-                                    "text": "x",
-                                    "rawText": "x",
-                                    "flags": 96,
-                                    "start": 97,
-                                    "end": 98
-                                },
-                                "optionalToken": null,
-                                "type": {
-                                    "kind": 139,
-                                    "type": {
-                                        "kind": 134234345,
-                                        "flags": 64,
-                                        "start": 99,
-                                        "end": 106
-                                    },
-                                    "flags": 0,
-                                    "start": 98,
-                                    "end": 106
-                                },
-                                "right": null,
+                "kind": 138,
+                "types": [
+                    {
+                        "kind": 260,
+                        "type": {
+                            "kind": 261,
+                            "arrowToken": {
+                                "kind": 10,
+                                "flags": 64,
+                                "start": 79,
+                                "end": 82
+                            },
+                            "parameters": {
+                                "kind": 279,
+                                "parameters": [
+                                    {
+                                        "kind": 149,
+                                        "ellipsisToken": null,
+                                        "name": {
+                                            "kind": 134299649,
+                                            "text": "x",
+                                            "rawText": "x",
+                                            "flags": 96,
+                                            "start": 69,
+                                            "end": 70
+                                        },
+                                        "optionalToken": null,
+                                        "types": {
+                                            "kind": 134234347,
+                                            "flags": 64,
+                                            "start": 71,
+                                            "end": 78
+                                        },
+                                        "flags": 0,
+                                        "start": 66,
+                                        "end": 78
+                                    }
+                                ],
+                                "trailingComma": false,
                                 "flags": 32,
-                                "start": 96,
+                                "start": 66,
+                                "end": 78
+                            },
+                            "returnType": {
+                                "kind": 134234345,
+                                "flags": 64,
+                                "start": 82,
+                                "end": 89
+                            },
+                            "typeParameters": null,
+                            "flags": 0,
+                            "start": 66,
+                            "end": 89
+                        },
+                        "flags": 0,
+                        "start": 66,
+                        "end": 90
+                    },
+                    {
+                        "kind": 260,
+                        "type": {
+                            "kind": 261,
+                            "arrowToken": {
+                                "kind": 10,
+                                "flags": 64,
+                                "start": 107,
+                                "end": 110
+                            },
+                            "parameters": {
+                                "kind": 279,
+                                "parameters": [
+                                    {
+                                        "kind": 149,
+                                        "ellipsisToken": null,
+                                        "name": {
+                                            "kind": 134299649,
+                                            "text": "x",
+                                            "rawText": "x",
+                                            "flags": 96,
+                                            "start": 97,
+                                            "end": 98
+                                        },
+                                        "optionalToken": null,
+                                        "types": {
+                                            "kind": 134234345,
+                                            "flags": 64,
+                                            "start": 99,
+                                            "end": 106
+                                        },
+                                        "flags": 0,
+                                        "start": 94,
+                                        "end": 106
+                                    }
+                                ],
+                                "trailingComma": false,
+                                "flags": 32,
+                                "start": 94,
                                 "end": 106
-                            }
-                        ],
-                        "asyncKeyword": null,
-                        "returnType": null,
-                        "contents": {
-                            "kind": 134299649,
-                            "text": "string",
-                            "rawText": "string",
-                            "flags": 96,
-                            "start": 110,
+                            },
+                            "returnType": {
+                                "kind": 134234347,
+                                "flags": 64,
+                                "start": 110,
+                                "end": 117
+                            },
+                            "typeParameters": null,
+                            "flags": 0,
+                            "start": 94,
                             "end": 117
                         },
-                        "flags": 32,
-                        "start": 96,
-                        "end": 117
-                    },
-                    "flags": 32,
-                    "start": 94,
-                    "end": 118
-                },
-                "flags": 32,
+                        "flags": 0,
+                        "start": 94,
+                        "end": 118
+                    }
+                ],
+                "flags": 0,
                 "start": 90,
                 "end": 118
             },
-            "flags": 16,
-            "start": 90,
+            "flags": 17,
+            "start": 44,
             "end": 120
         },
         {
@@ -572,16 +558,15 @@ type overloads2 = {
 
 ```javascript
 
+
+
+
+
 ```
 
 ### Diagnostics
 
 ```javascript
-✖ Expected a `;` - start: 70, end: 71
-✖ Expected a `;` - start: 78, end: 79
-✖ Declaration or statement expected - start: 79, end: 82
-✖ Expected a `;` - start: 89, end: 90
-✖ Identifier expected - start: 90, end: 94
-
+✔ No errors
 ```
 

--- a/test/__snapshot__/parser/declarations/var/array-type.md
+++ b/test/__snapshot__/parser/declarations/var/array-type.md
@@ -126,7 +126,16 @@ var a: (?number)[];
                                             "start": 28,
                                             "end": 31
                                         },
-                                        "parameters": [],
+                                        "parameters": {
+                                            "kind": 279,
+                                            "parameters": [
+                                                []
+                                            ],
+                                            "trailingComma": false,
+                                            "flags": 32,
+                                            "start": 24,
+                                            "end": 31
+                                        },
                                         "returnType": {
                                             "kind": 134234345,
                                             "flags": 64,

--- a/test/__snapshot__/parser/declarations/var/declare-var5.md
+++ b/test/__snapshot__/parser/declarations/var/declare-var5.md
@@ -71,7 +71,16 @@ declare var x3: ?(() => (() => number));
                                             "start": 20,
                                             "end": 23
                                         },
-                                        "parameters": [],
+                                        "parameters": {
+                                            "kind": 279,
+                                            "parameters": [
+                                                []
+                                            ],
+                                            "trailingComma": false,
+                                            "flags": 32,
+                                            "start": 17,
+                                            "end": 23
+                                        },
                                         "returnType": {
                                             "kind": 260,
                                             "type": {
@@ -82,7 +91,16 @@ declare var x3: ?(() => (() => number));
                                                     "start": 27,
                                                     "end": 30
                                                 },
-                                                "parameters": [],
+                                                "parameters": {
+                                                    "kind": 279,
+                                                    "parameters": [
+                                                        []
+                                                    ],
+                                                    "trailingComma": false,
+                                                    "flags": 32,
+                                                    "start": 23,
+                                                    "end": 30
+                                                },
                                                 "returnType": {
                                                     "kind": 134234345,
                                                     "flags": 64,

--- a/test/__snapshot__/parser/declarations/var/invalid-number-negative.md
+++ b/test/__snapshot__/parser/declarations/var/invalid-number-negative.md
@@ -77,7 +77,7 @@ var a: -z
             "expression": {
                 "kind": 126,
                 "operandToken": {
-                    "kind": 100915,
+                    "kind": 134318643,
                     "flags": 64,
                     "start": 6,
                     "end": 8

--- a/test/__snapshot__/parser/declarations/var/number-negative-octal.md
+++ b/test/__snapshot__/parser/declarations/var/number-negative-octal.md
@@ -51,7 +51,7 @@ var a: -0x7B
                             "type": {
                                 "kind": 271,
                                 "subtractionToken": {
-                                    "kind": 100915,
+                                    "kind": 134318643,
                                     "flags": 64,
                                     "start": 6,
                                     "end": 8

--- a/test/__snapshot__/parser/declarations/var/type-grouping2.md
+++ b/test/__snapshot__/parser/declarations/var/type-grouping2.md
@@ -61,7 +61,16 @@ var a: (() => number) | () => string
                                                 "start": 10,
                                                 "end": 13
                                             },
-                                            "parameters": [],
+                                            "parameters": {
+                                                "kind": 279,
+                                                "parameters": [
+                                                    []
+                                                ],
+                                                "trailingComma": false,
+                                                "flags": 32,
+                                                "start": 6,
+                                                "end": 13
+                                            },
                                             "returnType": {
                                                 "kind": 134234345,
                                                 "flags": 64,

--- a/test/__snapshot__/parser/expressions/array-literal/array-spread1.md
+++ b/test/__snapshot__/parser/expressions/array-literal/array-spread1.md
@@ -323,7 +323,7 @@ var y: Array<string> = ['3', ...x];
                                     "end": 68
                                 },
                                 "operatorToken": {
-                                    "kind": 100915,
+                                    "kind": 134318643,
                                     "flags": 64,
                                     "start": 68,
                                     "end": 70
@@ -427,7 +427,7 @@ var y: Array<string> = ['3', ...x];
                                     "end": 93
                                 },
                                 "operatorToken": {
-                                    "kind": 100915,
+                                    "kind": 134318643,
                                     "flags": 64,
                                     "start": 93,
                                     "end": 95

--- a/test/__snapshot__/parser/expressions/array-literal/array-with-negative-number.md
+++ b/test/__snapshot__/parser/expressions/array-literal/array-with-negative-number.md
@@ -52,7 +52,7 @@ const a = [ -1 ];
                                     {
                                         "kind": 126,
                                         "operandToken": {
-                                            "kind": 100915,
+                                            "kind": 134318643,
                                             "flags": 64,
                                             "start": 11,
                                             "end": 13

--- a/test/__snapshot__/parser/expressions/arrow/arrow-no-arg.md
+++ b/test/__snapshot__/parser/expressions/arrow/arrow-no-arg.md
@@ -56,7 +56,7 @@
                             "end": 11
                         },
                         "operatorToken": {
-                            "kind": 100915,
+                            "kind": 134318643,
                             "flags": 64,
                             "start": 11,
                             "end": 13

--- a/test/__snapshot__/parser/expressions/arrow/arrow-with-unary-expr.md
+++ b/test/__snapshot__/parser/expressions/arrow/arrow-with-unary-expr.md
@@ -25,7 +25,7 @@
                         {
                             "kind": 126,
                             "operandToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 1,
                                 "end": 2

--- a/test/__snapshot__/parser/expressions/arrow/gen/assignmen/x0028-ax0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/assignmen/x0028-ax0029_x003dx003e_x007bx007d.md
@@ -41,7 +41,7 @@ x = (-a) => {} ;
                     "expression": {
                         "kind": 126,
                         "operandToken": {
-                            "kind": 100915,
+                            "kind": 134318643,
                             "flags": 64,
                             "start": 5,
                             "end": 6

--- a/test/__snapshot__/parser/expressions/arrow/gen/assignmen/x0028a_-bx0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/assignmen/x0028a_-bx0029_x003dx003e_x007bx007d.md
@@ -52,7 +52,7 @@ x = (a, -b) => {} ;
                             {
                                 "kind": 126,
                                 "operandToken": {
-                                    "kind": 100915,
+                                    "kind": 134318643,
                                     "flags": 64,
                                     "start": 7,
                                     "end": 9

--- a/test/__snapshot__/parser/expressions/arrow/gen/assignmen/x0028a_b_-_cx0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/assignmen/x0028a_b_-_cx0029_x003dx003e_x007bx007d.md
@@ -60,7 +60,7 @@ x = (a, b - c) => {} ;
                                     "end": 9
                                 },
                                 "operatorToken": {
-                                    "kind": 100915,
+                                    "kind": 134318643,
                                     "flags": 64,
                                     "start": 9,
                                     "end": 11

--- a/test/__snapshot__/parser/expressions/arrow/gen/assignmen/x0028a_x002ex002ex002eb_-_10x0029_x003dx003e_b.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/assignmen/x0028a_x002ex002ex002eb_-_10x0029_x003dx003e_b.md
@@ -75,7 +75,7 @@ x = (a, ...b - 10) => b ;
                             {
                                 "kind": 126,
                                 "operandToken": {
-                                    "kind": 100915,
+                                    "kind": 134318643,
                                     "flags": 64,
                                     "start": 12,
                                     "end": 14

--- a/test/__snapshot__/parser/expressions/arrow/gen/assignmen/x0028x002ex002ex002erest_-_ax0029_x003dx003e_b.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/assignmen/x0028x002ex002ex002erest_-_ax0029_x003dx003e_b.md
@@ -52,7 +52,7 @@ x = (...rest - a) => b ;
                         "end": 12
                     },
                     "operatorToken": {
-                        "kind": 100915,
+                        "kind": 134318643,
                         "flags": 64,
                         "start": 12,
                         "end": 14

--- a/test/__snapshot__/parser/expressions/arrow/gen/condiional_paren_middle/x0028-ax0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/condiional_paren_middle/x0028-ax0029_x003dx003e_x007bx007d.md
@@ -43,7 +43,7 @@ bar ? ((-a) => {}) : baz;
                         "expression": {
                             "kind": 126,
                             "operandToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 8,
                                 "end": 9

--- a/test/__snapshot__/parser/expressions/arrow/gen/condiional_paren_middle/x0028a_-bx0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/condiional_paren_middle/x0028a_-bx0029_x003dx003e_x007bx007d.md
@@ -54,7 +54,7 @@ bar ? ((a, -b) => {}) : baz;
                                 {
                                     "kind": 126,
                                     "operandToken": {
-                                        "kind": 100915,
+                                        "kind": 134318643,
                                         "flags": 64,
                                         "start": 10,
                                         "end": 12

--- a/test/__snapshot__/parser/expressions/arrow/gen/condiional_paren_middle/x0028a_b_-_cx0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/condiional_paren_middle/x0028a_b_-_cx0029_x003dx003e_x007bx007d.md
@@ -62,7 +62,7 @@ bar ? ((a, b - c) => {}) : baz;
                                         "end": 12
                                     },
                                     "operatorToken": {
-                                        "kind": 100915,
+                                        "kind": 134318643,
                                         "flags": 64,
                                         "start": 12,
                                         "end": 14

--- a/test/__snapshot__/parser/expressions/arrow/gen/condiional_paren_middle/x0028a_x002ex002ex002eb_-_10x0029_x003dx003e_b.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/condiional_paren_middle/x0028a_x002ex002ex002eb_-_10x0029_x003dx003e_b.md
@@ -77,7 +77,7 @@ bar ? ((a, ...b - 10) => b) : baz;
                                 {
                                     "kind": 126,
                                     "operandToken": {
-                                        "kind": 100915,
+                                        "kind": 134318643,
                                         "flags": 64,
                                         "start": 15,
                                         "end": 17

--- a/test/__snapshot__/parser/expressions/arrow/gen/condiional_paren_middle/x0028x002ex002ex002erest_-_ax0029_x003dx003e_b.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/condiional_paren_middle/x0028x002ex002ex002erest_-_ax0029_x003dx003e_b.md
@@ -54,7 +54,7 @@ bar ? ((...rest - a) => b) : baz;
                             "end": 15
                         },
                         "operatorToken": {
-                            "kind": 100915,
+                            "kind": 134318643,
                             "flags": 64,
                             "start": 15,
                             "end": 17

--- a/test/__snapshot__/parser/expressions/arrow/gen/conditional/x0028-ax0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/conditional/x0028-ax0029_x003dx003e_x007bx007d.md
@@ -25,7 +25,7 @@
                 "expression": {
                     "kind": 126,
                     "operandToken": {
-                        "kind": 100915,
+                        "kind": 134318643,
                         "flags": 64,
                         "start": 1,
                         "end": 2

--- a/test/__snapshot__/parser/expressions/arrow/gen/conditional/x0028a_-bx0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/conditional/x0028a_-bx0029_x003dx003e_x007bx007d.md
@@ -36,7 +36,7 @@
                         {
                             "kind": 126,
                             "operandToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 3,
                                 "end": 5

--- a/test/__snapshot__/parser/expressions/arrow/gen/conditional/x0028a_b_-_cx0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/conditional/x0028a_b_-_cx0029_x003dx003e_x007bx007d.md
@@ -44,7 +44,7 @@
                                 "end": 5
                             },
                             "operatorToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 5,
                                 "end": 7

--- a/test/__snapshot__/parser/expressions/arrow/gen/conditional/x0028a_x002ex002ex002eb_-_10x0029_x003dx003e_b.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/conditional/x0028a_x002ex002ex002eb_-_10x0029_x003dx003e_b.md
@@ -59,7 +59,7 @@
                         {
                             "kind": 126,
                             "operandToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 8,
                                 "end": 10

--- a/test/__snapshot__/parser/expressions/arrow/gen/conditional/x0028x002ex002ex002erest_-_ax0029_x003dx003e_b.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/conditional/x0028x002ex002ex002erest_-_ax0029_x003dx003e_b.md
@@ -36,7 +36,7 @@
                     "end": 8
                 },
                 "operatorToken": {
-                    "kind": 100915,
+                    "kind": 134318643,
                     "flags": 64,
                     "start": 8,
                     "end": 10

--- a/test/__snapshot__/parser/expressions/arrow/gen/conditional_last/x0028-ax0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/conditional_last/x0028-ax0029_x003dx003e_x007bx007d.md
@@ -36,7 +36,7 @@ bar, (-a) => {};
                         "expression": {
                             "kind": 126,
                             "operandToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 6,
                                 "end": 7

--- a/test/__snapshot__/parser/expressions/arrow/gen/conditional_last/x0028a_-bx0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/conditional_last/x0028a_-bx0029_x003dx003e_x007bx007d.md
@@ -47,7 +47,7 @@ bar, (a, -b) => {};
                                 {
                                     "kind": 126,
                                     "operandToken": {
-                                        "kind": 100915,
+                                        "kind": 134318643,
                                         "flags": 64,
                                         "start": 8,
                                         "end": 10

--- a/test/__snapshot__/parser/expressions/arrow/gen/conditional_last/x0028a_b_-_cx0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/conditional_last/x0028a_b_-_cx0029_x003dx003e_x007bx007d.md
@@ -55,7 +55,7 @@ bar, (a, b - c) => {};
                                         "end": 10
                                     },
                                     "operatorToken": {
-                                        "kind": 100915,
+                                        "kind": 134318643,
                                         "flags": 64,
                                         "start": 10,
                                         "end": 12

--- a/test/__snapshot__/parser/expressions/arrow/gen/conditional_last/x0028a_x002ex002ex002eb_-_10x0029_x003dx003e_b.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/conditional_last/x0028a_x002ex002ex002eb_-_10x0029_x003dx003e_b.md
@@ -70,7 +70,7 @@ bar, (a, ...b - 10) => b;
                                 {
                                     "kind": 126,
                                     "operandToken": {
-                                        "kind": 100915,
+                                        "kind": 134318643,
                                         "flags": 64,
                                         "start": 13,
                                         "end": 15

--- a/test/__snapshot__/parser/expressions/arrow/gen/conditional_last/x0028x002ex002ex002erest_-_ax0029_x003dx003e_b.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/conditional_last/x0028x002ex002ex002erest_-_ax0029_x003dx003e_b.md
@@ -47,7 +47,7 @@ bar, (...rest - a) => b;
                             "end": 13
                         },
                         "operatorToken": {
-                            "kind": 100915,
+                            "kind": 134318643,
                             "flags": 64,
                             "start": 13,
                             "end": 15

--- a/test/__snapshot__/parser/expressions/arrow/gen/conditional_paren/x0028-ax0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/conditional_paren/x0028-ax0029_x003dx003e_x007bx007d.md
@@ -57,7 +57,7 @@ bar ? baz : ( (-a) => {} );
                         "expression": {
                             "kind": 126,
                             "operandToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 15,
                                 "end": 16

--- a/test/__snapshot__/parser/expressions/arrow/gen/conditional_paren/x0028a_-bx0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/conditional_paren/x0028a_-bx0029_x003dx003e_x007bx007d.md
@@ -68,7 +68,7 @@ bar ? baz : ( (a, -b) => {} );
                                 {
                                     "kind": 126,
                                     "operandToken": {
-                                        "kind": 100915,
+                                        "kind": 134318643,
                                         "flags": 64,
                                         "start": 17,
                                         "end": 19

--- a/test/__snapshot__/parser/expressions/arrow/gen/conditional_paren/x0028a_b_-_cx0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/conditional_paren/x0028a_b_-_cx0029_x003dx003e_x007bx007d.md
@@ -76,7 +76,7 @@ bar ? baz : ( (a, b - c) => {} );
                                         "end": 19
                                     },
                                     "operatorToken": {
-                                        "kind": 100915,
+                                        "kind": 134318643,
                                         "flags": 64,
                                         "start": 19,
                                         "end": 21

--- a/test/__snapshot__/parser/expressions/arrow/gen/conditional_paren/x0028a_x002ex002ex002eb_-_10x0029_x003dx003e_b.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/conditional_paren/x0028a_x002ex002ex002eb_-_10x0029_x003dx003e_b.md
@@ -91,7 +91,7 @@ bar ? baz : ( (a, ...b - 10) => b );
                                 {
                                     "kind": 126,
                                     "operandToken": {
-                                        "kind": 100915,
+                                        "kind": 134318643,
                                         "flags": 64,
                                         "start": 22,
                                         "end": 24

--- a/test/__snapshot__/parser/expressions/arrow/gen/conditional_paren/x0028x002ex002ex002erest_-_ax0029_x003dx003e_b.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/conditional_paren/x0028x002ex002ex002erest_-_ax0029_x003dx003e_b.md
@@ -68,7 +68,7 @@ bar ? baz : ( (...rest - a) => b );
                             "end": 22
                         },
                         "operatorToken": {
-                            "kind": 100915,
+                            "kind": 134318643,
                             "flags": 64,
                             "start": 22,
                             "end": 24

--- a/test/__snapshot__/parser/expressions/arrow/gen/stand-alone/x0028-ax0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/stand-alone/x0028-ax0029_x003dx003e_x007bx007d.md
@@ -25,7 +25,7 @@
                 "expression": {
                     "kind": 126,
                     "operandToken": {
-                        "kind": 100915,
+                        "kind": 134318643,
                         "flags": 64,
                         "start": 1,
                         "end": 2

--- a/test/__snapshot__/parser/expressions/arrow/gen/stand-alone/x0028a_-bx0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/stand-alone/x0028a_-bx0029_x003dx003e_x007bx007d.md
@@ -36,7 +36,7 @@
                         {
                             "kind": 126,
                             "operandToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 3,
                                 "end": 5

--- a/test/__snapshot__/parser/expressions/arrow/gen/stand-alone/x0028a_b_-_cx0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/stand-alone/x0028a_b_-_cx0029_x003dx003e_x007bx007d.md
@@ -44,7 +44,7 @@
                                 "end": 5
                             },
                             "operatorToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 5,
                                 "end": 7

--- a/test/__snapshot__/parser/expressions/arrow/gen/stand-alone/x0028a_x002ex002ex002eb_-_10x0029_x003dx003e_b.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/stand-alone/x0028a_x002ex002ex002eb_-_10x0029_x003dx003e_b.md
@@ -59,7 +59,7 @@
                         {
                             "kind": 126,
                             "operandToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 8,
                                 "end": 10

--- a/test/__snapshot__/parser/expressions/arrow/gen/stand-alone/x0028x002ex002ex002erest_-_ax0029_x003dx003e_b.md
+++ b/test/__snapshot__/parser/expressions/arrow/gen/stand-alone/x0028x002ex002ex002erest_-_ax0029_x003dx003e_b.md
@@ -36,7 +36,7 @@
                     "end": 8
                 },
                 "operatorToken": {
-                    "kind": 100915,
+                    "kind": 134318643,
                     "flags": 64,
                     "start": 8,
                     "end": 10

--- a/test/__snapshot__/parser/expressions/arrow/invalid-arrow2.md
+++ b/test/__snapshot__/parser/expressions/arrow/invalid-arrow2.md
@@ -258,7 +258,7 @@
                     "end": 66
                 },
                 "operatorToken": {
-                    "kind": 100915,
+                    "kind": 134318643,
                     "flags": 64,
                     "start": 66,
                     "end": 68

--- a/test/__snapshot__/parser/expressions/arrow/invalid-cases.md
+++ b/test/__snapshot__/parser/expressions/arrow/invalid-cases.md
@@ -5664,7 +5664,7 @@ a++ => {};
                                                         "end": 1272
                                                     },
                                                     "operatorToken": {
-                                                        "kind": 100915,
+                                                        "kind": 134318643,
                                                         "flags": 64,
                                                         "start": 1272,
                                                         "end": 1273
@@ -5819,7 +5819,7 @@ a++ => {};
                                                             "end": 1305
                                                         },
                                                         "operatorToken": {
-                                                            "kind": 100915,
+                                                            "kind": 134318643,
                                                             "flags": 64,
                                                             "start": 1305,
                                                             "end": 1306
@@ -6238,7 +6238,7 @@ a++ => {};
                                                                                     "end": 1405
                                                                                 },
                                                                                 "operatorToken": {
-                                                                                    "kind": 100915,
+                                                                                    "kind": 134318643,
                                                                                     "flags": 64,
                                                                                     "start": 1405,
                                                                                     "end": 1406
@@ -9187,7 +9187,7 @@ a++ => {};
                                 "end": 2981
                             },
                             "operatorToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 2981,
                                 "end": 2983
@@ -9383,7 +9383,7 @@ a++ => {};
             "expression": {
                 "kind": 126,
                 "operandToken": {
-                    "kind": 100915,
+                    "kind": 134318643,
                     "flags": 65,
                     "start": 3048,
                     "end": 3050
@@ -9440,7 +9440,7 @@ a++ => {};
                 "expression": {
                     "kind": 126,
                     "operandToken": {
-                        "kind": 100915,
+                        "kind": 134318643,
                         "flags": 64,
                         "start": 3060,
                         "end": 3061
@@ -9494,7 +9494,7 @@ a++ => {};
                         {
                             "kind": 126,
                             "operandToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 3072,
                                 "end": 3073
@@ -9569,7 +9569,7 @@ a++ => {};
                         {
                             "kind": 126,
                             "operandToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 3089,
                                 "end": 3091
@@ -10517,7 +10517,7 @@ a++ => {};
                     "end": 3354
                 },
                 "operatorToken": {
-                    "kind": 100915,
+                    "kind": 134318643,
                     "flags": 64,
                     "start": 3354,
                     "end": 3356
@@ -10593,7 +10593,7 @@ a++ => {};
                         {
                             "kind": 126,
                             "operandToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 3374,
                                 "end": 3376

--- a/test/__snapshot__/parser/expressions/await/await_is_a_valid_identifier_in_script_mode_5.md
+++ b/test/__snapshot__/parser/expressions/await/await_is_a_valid_identifier_in_script_mode_5.md
@@ -28,7 +28,7 @@ await - 25
                     "end": 5
                 },
                 "operatorToken": {
-                    "kind": 100915,
+                    "kind": 134318643,
                     "flags": 64,
                     "start": 5,
                     "end": 7

--- a/test/__snapshot__/parser/expressions/binary/binary-operators.md
+++ b/test/__snapshot__/parser/expressions/binary/binary-operators.md
@@ -78,7 +78,7 @@ a, b;
                     "end": 8
                 },
                 "operatorToken": {
-                    "kind": 100915,
+                    "kind": 134318643,
                     "flags": 64,
                     "start": 8,
                     "end": 10

--- a/test/__snapshot__/parser/expressions/binary/div_and_lhs_xor_gt_min_lor_land_seq_or_pow.one.md
+++ b/test/__snapshot__/parser/expressions/binary/div_and_lhs_xor_gt_min_lor_land_seq_or_pow.one.md
@@ -122,7 +122,7 @@ x0 / x1 & x2 << x3 ^ x4 > x5 - x6 || x7 && x8 === x9 | x10 ** x
                                 "end": 28
                             },
                             "operatorToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 28,
                                 "end": 30

--- a/test/__snapshot__/parser/expressions/binary/div_and_rhs_xor_gt_min_lor_land_neq_or_pow.one.rev.md
+++ b/test/__snapshot__/parser/expressions/binary/div_and_rhs_xor_gt_min_lor_land_neq_or_pow.one.rev.md
@@ -122,7 +122,7 @@ x0 / x1 & x2 >> x3 ^ x4 > x5 - x6 || x7 && x8 != x9 | x10 ** x
                                 "end": 28
                             },
                             "operatorToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 28,
                                 "end": 30

--- a/test/__snapshot__/parser/expressions/binary/lhs_and_in_land_lor_xor_mul_pow_or_neq_min.two.rev.md
+++ b/test/__snapshot__/parser/expressions/binary/lhs_and_in_land_lor_xor_mul_pow_or_neq_min.two.rev.md
@@ -217,7 +217,7 @@ x0 << x1 & x2 in x3 && x4 || x5 ^ x6 * x7 ** x8 | x9 != x10 - x
                                 "end": 59
                             },
                             "operatorToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 59,
                                 "end": 61

--- a/test/__snapshot__/parser/expressions/binary/min_eq_or_pow_div_xor_lor_land_lt_and_lhs.two.md
+++ b/test/__snapshot__/parser/expressions/binary/min_eq_or_pow_div_xor_lor_land_lt_and_lhs.two.md
@@ -34,7 +34,7 @@ x0 - x1 == x2 | x3 ** x4 / x5 ^ x6 || x7 && x8 < x9 & x10 << x
                                 "end": 2
                             },
                             "operatorToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 2,
                                 "end": 4

--- a/test/__snapshot__/parser/expressions/binary/min_neq_or_pow_percent_xor_lor_land_gte_and_urhs.two.md
+++ b/test/__snapshot__/parser/expressions/binary/min_neq_or_pow_percent_xor_lor_land_gte_and_urhs.two.md
@@ -34,7 +34,7 @@ x0 - x1 != x2 | x3 ** x4 % x5 ^ x6 || x7 && x8 >= x9 & x10 >>> x
                                 "end": 2
                             },
                             "operatorToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 2,
                                 "end": 4

--- a/test/__snapshot__/parser/expressions/binary/min_seq_or_pow_mul_xor_lor_land_gte_and_rhs.two.md
+++ b/test/__snapshot__/parser/expressions/binary/min_seq_or_pow_mul_xor_lor_land_gte_and_rhs.two.md
@@ -36,7 +36,7 @@ typeof x;
                                 "end": 2
                             },
                             "operatorToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 2,
                                 "end": 4

--- a/test/__snapshot__/parser/expressions/binary/min_sneq_or_pow_mul_xor_lor_land_lt_and_lhs.two.md
+++ b/test/__snapshot__/parser/expressions/binary/min_sneq_or_pow_mul_xor_lor_land_lt_and_lhs.two.md
@@ -34,7 +34,7 @@ x0 - x1 !== x2 | x3 ** x4 * x5 ^ x6 || x7 && x8 < x9 & x10 << x
                                 "end": 2
                             },
                             "operatorToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 2,
                                 "end": 4

--- a/test/__snapshot__/parser/expressions/binary/negative-prefix.md
+++ b/test/__snapshot__/parser/expressions/binary/negative-prefix.md
@@ -20,7 +20,7 @@
             "expression": {
                 "kind": 126,
                 "operandToken": {
-                    "kind": 100915,
+                    "kind": 134318643,
                     "flags": 64,
                     "start": 0,
                     "end": 1

--- a/test/__snapshot__/parser/expressions/binary/negative_lhs_is_not_allowed.md
+++ b/test/__snapshot__/parser/expressions/binary/negative_lhs_is_not_allowed.md
@@ -24,7 +24,7 @@
                     "left": {
                         "kind": 126,
                         "operandToken": {
-                            "kind": 100915,
+                            "kind": 134318643,
                             "flags": 64,
                             "start": 1,
                             "end": 2

--- a/test/__snapshot__/parser/expressions/binary/nested-unary-before-exponential.md
+++ b/test/__snapshot__/parser/expressions/binary/nested-unary-before-exponential.md
@@ -24,7 +24,7 @@
                     "left": {
                         "kind": 126,
                         "operandToken": {
-                            "kind": 100915,
+                            "kind": 134318643,
                             "flags": 64,
                             "start": 1,
                             "end": 2

--- a/test/__snapshot__/parser/expressions/binary/valid-cases.md
+++ b/test/__snapshot__/parser/expressions/binary/valid-cases.md
@@ -84,7 +84,7 @@ typeof a == 'b';
                     "end": 8
                 },
                 "operatorToken": {
-                    "kind": 100915,
+                    "kind": 134318643,
                     "flags": 64,
                     "start": 8,
                     "end": 10

--- a/test/__snapshot__/parser/expressions/call/valid-cases.md
+++ b/test/__snapshot__/parser/expressions/call/valid-cases.md
@@ -324,7 +324,7 @@ x(class {} ?? 1);
                             "left": {
                                 "kind": 126,
                                 "operandToken": {
-                                    "kind": 100915,
+                                    "kind": 134318643,
                                     "flags": 64,
                                     "start": 67,
                                     "end": 68
@@ -632,7 +632,7 @@ x(class {} ?? 1);
                                         "end": 137
                                     },
                                     "operatorToken": {
-                                        "kind": 100915,
+                                        "kind": 134318643,
                                         "flags": 64,
                                         "start": 137,
                                         "end": 139

--- a/test/__snapshot__/parser/expressions/classes/extends-lefthandside/gen/async_wrapped/-x.md
+++ b/test/__snapshot__/parser/expressions/classes/extends-lefthandside/gen/async_wrapped/-x.md
@@ -90,7 +90,7 @@ async function p(){
                                     "expression": {
                                         "kind": 126,
                                         "operandToken": {
-                                            "kind": 100915,
+                                            "kind": 134318643,
                                             "flags": 64,
                                             "start": 37,
                                             "end": 39

--- a/test/__snapshot__/parser/expressions/classes/extends-lefthandside/gen/declaration/-x.md
+++ b/test/__snapshot__/parser/expressions/classes/extends-lefthandside/gen/declaration/-x.md
@@ -50,7 +50,7 @@ class A extends -x {}
                     "expression": {
                         "kind": 126,
                         "operandToken": {
-                            "kind": 100915,
+                            "kind": 134318643,
                             "flags": 64,
                             "start": 15,
                             "end": 17

--- a/test/__snapshot__/parser/expressions/classes/extends-lefthandside/gen/expression/-x.md
+++ b/test/__snapshot__/parser/expressions/classes/extends-lefthandside/gen/expression/-x.md
@@ -53,7 +53,7 @@
                             "expression": {
                                 "kind": 126,
                                 "operandToken": {
-                                    "kind": 100915,
+                                    "kind": 134318643,
                                     "flags": 64,
                                     "start": 16,
                                     "end": 18

--- a/test/__snapshot__/parser/expressions/classes/extends-lefthandside/gen/for-in_lhs/-x.md
+++ b/test/__snapshot__/parser/expressions/classes/extends-lefthandside/gen/for-in_lhs/-x.md
@@ -29,7 +29,7 @@ for (-x in x) ;
             "initializer": {
                 "kind": 126,
                 "operandToken": {
-                    "kind": 100915,
+                    "kind": 134318643,
                     "flags": 64,
                     "start": 5,
                     "end": 6

--- a/test/__snapshot__/parser/expressions/classes/extends-lefthandside/gen/generator_wrapped/-x.md
+++ b/test/__snapshot__/parser/expressions/classes/extends-lefthandside/gen/generator_wrapped/-x.md
@@ -90,7 +90,7 @@ function *P(){
                                     "expression": {
                                         "kind": 126,
                                         "operandToken": {
-                                            "kind": 100915,
+                                            "kind": 134318643,
                                             "flags": 64,
                                             "start": 32,
                                             "end": 34

--- a/test/__snapshot__/parser/expressions/classes/extends-lefthandside/gen/new_arg/-x.md
+++ b/test/__snapshot__/parser/expressions/classes/extends-lefthandside/gen/new_arg/-x.md
@@ -31,7 +31,7 @@ new -x
                 "expression": {
                     "kind": 126,
                     "operandToken": {
-                        "kind": 100915,
+                        "kind": 134318643,
                         "flags": 64,
                         "start": 3,
                         "end": 5

--- a/test/__snapshot__/parser/expressions/classes/malformed-super-expression.md
+++ b/test/__snapshot__/parser/expressions/classes/malformed-super-expression.md
@@ -109,7 +109,7 @@ class A {
                                                         "end": 28
                                                     },
                                                     "operatorToken": {
-                                                        "kind": 100915,
+                                                        "kind": 134318643,
                                                         "flags": 64,
                                                         "start": 28,
                                                         "end": 30

--- a/test/__snapshot__/parser/expressions/conditional/valid-cases.md
+++ b/test/__snapshot__/parser/expressions/conditional/valid-cases.md
@@ -1213,7 +1213,7 @@ a ? b.c(d + e[f]) : b.c(d + e[g]);
                             "alternate": {
                                 "kind": 126,
                                 "operandToken": {
-                                    "kind": 100915,
+                                    "kind": 134318643,
                                     "flags": 64,
                                     "start": 273,
                                     "end": 275
@@ -1365,7 +1365,7 @@ a ? b.c(d + e[f]) : b.c(d + e[g]);
                             "consequent": {
                                 "kind": 126,
                                 "operandToken": {
-                                    "kind": 100915,
+                                    "kind": 134318643,
                                     "flags": 64,
                                     "start": 299,
                                     "end": 301
@@ -1483,7 +1483,7 @@ a ? b.c(d + e[f]) : b.c(d + e[g]);
                 "consequent": {
                     "kind": 126,
                     "operandToken": {
-                        "kind": 100915,
+                        "kind": 134318643,
                         "flags": 64,
                         "start": 325,
                         "end": 327
@@ -1509,7 +1509,7 @@ a ? b.c(d + e[f]) : b.c(d + e[g]);
                 "alternate": {
                     "kind": 126,
                     "operandToken": {
-                        "kind": 100915,
+                        "kind": 134318643,
                         "flags": 64,
                         "start": 330,
                         "end": 332
@@ -2403,7 +2403,7 @@ a ? b.c(d + e[f]) : b.c(d + e[g]);
                 "consequent": {
                     "kind": 126,
                     "operandToken": {
-                        "kind": 100915,
+                        "kind": 134318643,
                         "flags": 64,
                         "start": 499,
                         "end": 501

--- a/test/__snapshot__/parser/expressions/logical-assignment/valid-cases.md
+++ b/test/__snapshot__/parser/expressions/logical-assignment/valid-cases.md
@@ -960,7 +960,7 @@ x((y ?? z) ?? 1);
                             "left": {
                                 "kind": 126,
                                 "operandToken": {
-                                    "kind": 100915,
+                                    "kind": 134318643,
                                     "flags": 64,
                                     "start": 202,
                                     "end": 203
@@ -2081,7 +2081,7 @@ x((y ?? z) ?? 1);
                                         "end": 432
                                     },
                                     "operatorToken": {
-                                        "kind": 100915,
+                                        "kind": 134318643,
                                         "flags": 64,
                                         "start": 432,
                                         "end": 434

--- a/test/__snapshot__/parser/expressions/template/negative-prefix.md
+++ b/test/__snapshot__/parser/expressions/template/negative-prefix.md
@@ -20,7 +20,7 @@
             "expression": {
                 "kind": 126,
                 "operandToken": {
-                    "kind": 100915,
+                    "kind": 134318643,
                     "flags": 64,
                     "start": 0,
                     "end": 1

--- a/test/__snapshot__/parser/expressions/unary/complex.md
+++ b/test/__snapshot__/parser/expressions/unary/complex.md
@@ -246,7 +246,7 @@ function x8(a: false & false): false {
                             "expression": {
                                 "kind": 126,
                                 "operandToken": {
-                                    "kind": 100915,
+                                    "kind": 134318643,
                                     "flags": 64,
                                     "start": 126,
                                     "end": 128

--- a/test/__snapshot__/parser/expressions/unary/negative-prefix.md
+++ b/test/__snapshot__/parser/expressions/unary/negative-prefix.md
@@ -20,7 +20,7 @@
             "expression": {
                 "kind": 126,
                 "operandToken": {
-                    "kind": 100915,
+                    "kind": 134318643,
                     "flags": 64,
                     "start": 0,
                     "end": 1

--- a/test/__snapshot__/parser/expressions/unary/negative_prefix_-x.md
+++ b/test/__snapshot__/parser/expressions/unary/negative_prefix_-x.md
@@ -20,7 +20,7 @@
             "expression": {
                 "kind": 126,
                 "operandToken": {
-                    "kind": 100915,
+                    "kind": 134318643,
                     "flags": 64,
                     "start": 0,
                     "end": 1

--- a/test/__snapshot__/parser/expressions/unary/some-valid-cases.md
+++ b/test/__snapshot__/parser/expressions/unary/some-valid-cases.md
@@ -313,7 +313,7 @@ typeof (0 ? 1 : x);
                             {
                                 "kind": 126,
                                 "operandToken": {
-                                    "kind": 100915,
+                                    "kind": 134318643,
                                     "flags": 64,
                                     "start": 106,
                                     "end": 108
@@ -373,7 +373,7 @@ typeof (0 ? 1 : x);
                             {
                                 "kind": 126,
                                 "operandToken": {
-                                    "kind": 100915,
+                                    "kind": 134318643,
                                     "flags": 64,
                                     "start": 130,
                                     "end": 132
@@ -714,7 +714,7 @@ typeof (0 ? 1 : x);
             "expression": {
                 "kind": 126,
                 "operandToken": {
-                    "kind": 100915,
+                    "kind": 134318643,
                     "flags": 65,
                     "start": 237,
                     "end": 240

--- a/test/__snapshot__/parser/miscellaneous/destructuring/failing-cases/gen/function_param_list/ax003a_x0028x0028typeof_x0028ax0029x0029x0029_x003ex003ex003ex003d_a_x007cx007c_bx002el_x0026x0026_c.md
+++ b/test/__snapshot__/parser/miscellaneous/destructuring/failing-cases/gen/function_param_list/ax003a_x0028x0028typeof_x0028ax0029x0029x0029_x003ex003ex003ex003d_a_x007cx007c_bx002el_x0026x0026_c.md
@@ -71,12 +71,12 @@ function x(a: ((typeof (a))) >>>= a || b.l && c) {}
                     "directives": [],
                     "statements": [],
                     "flags": 32,
-                    "start": 28,
-                    "end": 28
+                    "start": 22,
+                    "end": 22
                 },
                 "flags": 32,
-                "start": 28,
-                "end": 28
+                "start": 22,
+                "end": 22
             },
             "typeParameters": null,
             "returnType": {
@@ -84,49 +84,44 @@ function x(a: ((typeof (a))) >>>= a || b.l && c) {}
                 "type": {
                     "kind": 260,
                     "type": {
-                        "kind": 134299891,
-                        "typeOfKeyword": {
-                            "kind": 138477613,
-                            "flags": 64,
-                            "start": 16,
-                            "end": 22
-                        },
-                        "type": {
-                            "kind": 260,
-                            "type": {
-                                "kind": 144,
-                                "id": {
-                                    "kind": 134299649,
-                                    "text": "a",
-                                    "rawText": "a",
-                                    "flags": 96,
-                                    "start": 24,
-                                    "end": 25
-                                },
-                                "typeParameters": null,
-                                "flags": 0,
-                                "start": 22,
-                                "end": 25
-                            },
-                            "flags": 0,
-                            "start": 22,
-                            "end": 26
-                        },
-                        "flags": 0,
+                        "kind": 134299649,
+                        "text": "typeof",
+                        "rawText": "typeof",
+                        "flags": 96,
                         "start": 16,
-                        "end": 26
+                        "end": 22
                     },
                     "flags": 0,
                     "start": 13,
-                    "end": 28
+                    "end": 22
                 },
                 "flags": 0,
                 "start": 0,
-                "end": 28
+                "end": 22
             },
             "flags": 16,
             "start": 0,
-            "end": 28
+            "end": 22
+        },
+        {
+            "kind": 120,
+            "expression": {
+                "kind": 121,
+                "expression": {
+                    "kind": 134299649,
+                    "text": "a",
+                    "rawText": "a",
+                    "flags": 96,
+                    "start": 24,
+                    "end": 25
+                },
+                "flags": 32,
+                "start": 22,
+                "end": 26
+            },
+            "flags": 16,
+            "start": 22,
+            "end": 26
         },
         {
             "kind": 120,
@@ -229,7 +224,10 @@ function x(a: ((typeof (a))) >>>= a || b.l && c) {}
 
 ```javascript
 ✖ ',' expected - start: 12, end: 13
-✖ Missing an opening brace - '{ - start: 28, end: 33
+✖ Missing an opening brace - '{ - start: 22, end: 24
+✖ Expected a `;` - start: 26, end: 27
+✖ Declaration or statement expected - start: 27, end: 28
+✖ Declaration or statement expected - start: 28, end: 33
 ✖ Expected a `;` - start: 47, end: 48
 
 ```

--- a/test/__snapshot__/parser/miscellaneous/should-fail/gen/in_a_block/-x00285x0029_x002ax002a_6_.md
+++ b/test/__snapshot__/parser/miscellaneous/should-fail/gen/in_a_block/-x00285x0029_x002ax002a_6_.md
@@ -30,7 +30,7 @@
                             "left": {
                                 "kind": 126,
                                 "operandToken": {
-                                    "kind": 100915,
+                                    "kind": 134318643,
                                     "flags": 64,
                                     "start": 1,
                                     "end": 3

--- a/test/__snapshot__/parser/miscellaneous/should-fail/gen/in_a_block/x0028-a_bx0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/miscellaneous/should-fail/gen/in_a_block/x0028-a_bx0029_x003dx003e_x007bx007d.md
@@ -33,7 +33,7 @@
                                     {
                                         "kind": 126,
                                         "operandToken": {
-                                            "kind": 100915,
+                                            "kind": 134318643,
                                             "flags": 64,
                                             "start": 3,
                                             "end": 4

--- a/test/__snapshot__/parser/miscellaneous/should-fail/gen/in_a_block/x0028a_-bx0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/miscellaneous/should-fail/gen/in_a_block/x0028a_-bx0029_x003dx003e_x007bx007d.md
@@ -41,7 +41,7 @@
                                     {
                                         "kind": 126,
                                         "operandToken": {
-                                            "kind": 100915,
+                                            "kind": 134318643,
                                             "flags": 64,
                                             "start": 5,
                                             "end": 7

--- a/test/__snapshot__/parser/miscellaneous/should-fail/gen/stand-alone/-x00285x0029_x002ax002a_6_.md
+++ b/test/__snapshot__/parser/miscellaneous/should-fail/gen/stand-alone/-x00285x0029_x002ax002a_6_.md
@@ -25,7 +25,7 @@
                 "left": {
                     "kind": 126,
                     "operandToken": {
-                        "kind": 100915,
+                        "kind": 134318643,
                         "flags": 64,
                         "start": 0,
                         "end": 1

--- a/test/__snapshot__/parser/miscellaneous/should-fail/gen/stand-alone/x0028-a_bx0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/miscellaneous/should-fail/gen/stand-alone/x0028-a_bx0029_x003dx003e_x007bx007d.md
@@ -28,7 +28,7 @@
                         {
                             "kind": 126,
                             "operandToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 1,
                                 "end": 2

--- a/test/__snapshot__/parser/miscellaneous/should-fail/gen/stand-alone/x0028a_-bx0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/miscellaneous/should-fail/gen/stand-alone/x0028a_-bx0029_x003dx003e_x007bx007d.md
@@ -36,7 +36,7 @@
                         {
                             "kind": 126,
                             "operandToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 3,
                                 "end": 5

--- a/test/__snapshot__/parser/miscellaneous/should-fail/gen/with_strict_directive/-x00285x0029_x002ax002a_6_.md
+++ b/test/__snapshot__/parser/miscellaneous/should-fail/gen/with_strict_directive/-x00285x0029_x002ax002a_6_.md
@@ -34,7 +34,7 @@
                 "left": {
                     "kind": 126,
                     "operandToken": {
-                        "kind": 100915,
+                        "kind": 134318643,
                         "flags": 64,
                         "start": 13,
                         "end": 15

--- a/test/__snapshot__/parser/miscellaneous/should-fail/gen/with_strict_directive/x0028-a_bx0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/miscellaneous/should-fail/gen/with_strict_directive/x0028-a_bx0029_x003dx003e_x007bx007d.md
@@ -37,7 +37,7 @@
                         {
                             "kind": 126,
                             "operandToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 15,
                                 "end": 16

--- a/test/__snapshot__/parser/miscellaneous/should-fail/gen/with_strict_directive/x0028a_-bx0029_x003dx003e_x007bx007d.md
+++ b/test/__snapshot__/parser/miscellaneous/should-fail/gen/with_strict_directive/x0028a_-bx0029_x003dx003e_x007bx007d.md
@@ -45,7 +45,7 @@
                         {
                             "kind": 126,
                             "operandToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 17,
                                 "end": 19

--- a/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/--a_-_x002b_x002bx002bb.md
+++ b/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/--a_-_x002b_x002bx002bb.md
@@ -43,7 +43,7 @@
                     "end": 3
                 },
                 "operatorToken": {
-                    "kind": 100915,
+                    "kind": 134318643,
                     "flags": 64,
                     "start": 3,
                     "end": 5

--- a/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/-ax002bx002b-_-bx002bx002b.md
+++ b/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/-ax002bx002b-_-bx002bx002b.md
@@ -25,7 +25,7 @@
                 "left": {
                     "kind": 126,
                     "operandToken": {
-                        "kind": 100915,
+                        "kind": 134318643,
                         "flags": 64,
                         "start": 0,
                         "end": 1
@@ -55,7 +55,7 @@
                     "end": 4
                 },
                 "operatorToken": {
-                    "kind": 100915,
+                    "kind": 134318643,
                     "flags": 64,
                     "start": 4,
                     "end": 5
@@ -63,7 +63,7 @@
                 "right": {
                     "kind": 126,
                     "operandToken": {
-                        "kind": 100915,
+                        "kind": 134318643,
                         "flags": 64,
                         "start": 5,
                         "end": 7

--- a/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/1_x002a_x0028x0028x00282_x002b_3x0029_x002f_4x0029_x002a_x0028x00285x0029_x002f_6_x002b_7x0029_-_8x0029.md
+++ b/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/1_x002a_x0028x0028x00282_x002b_3x0029_x002f_4x0029_x002a_x0028x00285x0029_x002f_6_x002b_7x0029_-_8x0029.md
@@ -169,7 +169,7 @@
                                 "end": 34
                             },
                             "operatorToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 34,
                                 "end": 36

--- a/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/1_x002b_x007bget_getx0028x0029x007bx007d_set_setx0028ax0029x007bx007d_get1x003a4_set1x003aget-set_x007d.md
+++ b/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/1_x002b_x007bget_getx0028x0029x007bx007d_set_setx0028ax0029x007bx007d_get1x003a4_set1x003aget-set_x007d.md
@@ -201,7 +201,7 @@
                                         "end": 48
                                     },
                                     "operatorToken": {
-                                        "kind": 100915,
+                                        "kind": 134318643,
                                         "flags": 64,
                                         "start": 48,
                                         "end": 49

--- a/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/a_in_b_instanceof_delete_-c.md
+++ b/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/a_in_b_instanceof_delete_-c.md
@@ -67,7 +67,7 @@ a in b instanceof delete -c
                     "operand": {
                         "kind": 126,
                         "operandToken": {
-                            "kind": 100915,
+                            "kind": 134318643,
                             "flags": 64,
                             "start": 24,
                             "end": 26

--- a/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/arrObj0x005b0x005d_x003d_-1482624655_.md
+++ b/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/arrObj0x005b0x005d_x003d_-1482624655_.md
@@ -53,7 +53,7 @@ arrObj0[0] = -1482624655;
                 "right": {
                     "kind": 126,
                     "operandToken": {
-                        "kind": 100915,
+                        "kind": 134318643,
                         "flags": 64,
                         "start": 12,
                         "end": 14

--- a/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/function_fx0028x0029_x007b_1_x002b_x007bget_getx0028x0029x007bx007d_set_setx0028ax0029x007bx007d_get1x003a4_set1x003aget-set_x00.md
+++ b/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/function_fx0028x0029_x007b_1_x002b_x007bget_getx0028x0029x007bx007d_set_setx0028ax0029x007bx007d_get1x003a4_set1x003aget-set_x00.md
@@ -234,7 +234,7 @@ function f() { 1 + {get get(){}, set set(a){}, get1:4, set1:get-set, } }
                                                         "end": 63
                                                     },
                                                     "operatorToken": {
-                                                        "kind": 100915,
+                                                        "kind": 134318643,
                                                         "flags": 64,
                                                         "start": 63,
                                                         "end": 64

--- a/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/function_fx0028x0029_x007b_x00284_x00285_ax00283_4x0029x0029x0029_fx005b4_a-6x005d_x007d.md
+++ b/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/function_fx0028x0029_x007b_x00284_x00285_ax00283_4x0029x0029x0029_fx005b4_a-6x005d_x007d.md
@@ -171,7 +171,7 @@ function f() { (4,(5,a(3,4))),f[4,a-6] }
                                                         "end": 35
                                                     },
                                                     "operatorToken": {
-                                                        "kind": 100915,
+                                                        "kind": 134318643,
                                                         "flags": 64,
                                                         "start": 35,
                                                         "end": 36

--- a/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/new_x0028-1x0029.md
+++ b/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/new_x0028-1x0029.md
@@ -33,7 +33,7 @@ new (-1)
                     "expression": {
                         "kind": 126,
                         "operandToken": {
-                            "kind": 100915,
+                            "kind": 134318643,
                             "flags": 64,
                             "start": 5,
                             "end": 6

--- a/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/new_x0028f_x002b_5x0029x00286_x0028gx0029x0028x0029_-_x0027lx0027x0028x0029_-_truex0028falsex0029x0029.md
+++ b/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/new_x0028f_x002b_5x0029x00286_x0028gx0029x0028x0029_-_x0027lx0027x0028x0029_-_truex0028falsex0029x0029.md
@@ -106,7 +106,7 @@ new (f + 5)(6, (g)() - 'l'() - true(false))
                                     "end": 20
                                 },
                                 "operatorToken": {
-                                    "kind": 100915,
+                                    "kind": 134318643,
                                     "flags": 64,
                                     "start": 20,
                                     "end": 22
@@ -138,7 +138,7 @@ new (f + 5)(6, (g)() - 'l'() - true(false))
                                 "end": 28
                             },
                             "operatorToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 28,
                                 "end": 30

--- a/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/switch_x0028fx0028x0029x0029_x007b_case_5_x002a_fx0028x0029x003a_defaultx003a_case_x00276x0027_-_9x003a_x002bx002bi_x007d.md
+++ b/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/switch_x0028fx0028x0029x0029_x007b_case_5_x002a_fx0028x0029x003a_defaultx003a_case_x00276x0027_-_9x003a_x002bx002bi_x007d.md
@@ -138,7 +138,7 @@ switch (f()) { case 5 * f(): default: case '6' - 9: ++i }
                                 "end": 46
                             },
                             "operatorToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 46,
                                 "end": 48

--- a/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/switch_x0028swx0029_x007b_case_a_x003f_b_-_7x005b1x005d_x003f_x005bc_x005d_x003a_d_x003d_6_x003a_x007b_x007d_x003a_x007d.md
+++ b/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/switch_x0028swx0029_x007b_case_a_x003f_b_-_7x005b1x005d_x003f_x005bc_x005d_x003a_d_x003d_6_x003a_x007b_x007d_x003a_x007d.md
@@ -74,7 +74,7 @@ switch (sw) { case a ? b - 7[1] ? [c,,] : d = 6 : { } : }
                                         "end": 24
                                     },
                                     "operatorToken": {
-                                        "kind": 100915,
+                                        "kind": 134318643,
                                         "flags": 64,
                                         "start": 24,
                                         "end": 26

--- a/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/var_x_x003d_42_x002fx002ax005cnx002ax002f--x003eis_eol-commentx005cnvar_y_x003d_37_.md
+++ b/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/var_x_x003d_42_x002fx002ax005cnx002ax002f--x003eis_eol-commentx005cnvar_y_x003d_37_.md
@@ -121,7 +121,7 @@ var x = 42;/*\n*/-->is eol-comment\nvar y = 37;
                     "end": 26
                 },
                 "operatorToken": {
-                    "kind": 100915,
+                    "kind": 134318643,
                     "flags": 64,
                     "start": 26,
                     "end": 27

--- a/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/x0028evalx0029_a_x003d_x0028x0028x0028x0028x0028x0028-2e308x0029x0029x0029x0029x002eifx0029x0028x002ex002ex002ex0028x0028thisx00.md
+++ b/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/x0028evalx0029_a_x003d_x0028x0028x0028x0028x0028x0028-2e308x0029x0029x0029x0029x002eifx0029x0028x002ex002ex002ex0028x0028thisx00.md
@@ -72,7 +72,7 @@
                                                         "expression": {
                                                             "kind": 126,
                                                             "operandToken": {
-                                                                "kind": 100915,
+                                                                "kind": 134318643,
                                                                 "flags": 64,
                                                                 "start": 18,
                                                                 "end": 19

--- a/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/x0028x007byx003ay2x007d_x003d_x007byx003ay2-2x007dx0029.md
+++ b/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/x0028x007byx003ay2x007d_x003d_x007byx003ay2-2x007dx0029.md
@@ -95,7 +95,7 @@
                                             "end": 15
                                         },
                                         "operatorToken": {
-                                            "kind": 100915,
+                                            "kind": 134318643,
                                             "flags": 64,
                                             "start": 15,
                                             "end": 16

--- a/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/x002bx002ba_-_-_--b.md
+++ b/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/x002bx002ba_-_-_--b.md
@@ -43,7 +43,7 @@
                     "end": 3
                 },
                 "operatorToken": {
-                    "kind": 100915,
+                    "kind": 134318643,
                     "flags": 64,
                     "start": 3,
                     "end": 5
@@ -51,7 +51,7 @@
                 "right": {
                     "kind": 126,
                     "operandToken": {
-                        "kind": 100915,
+                        "kind": 134318643,
                         "flags": 64,
                         "start": 5,
                         "end": 7

--- a/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/x002bx002ba_-_b--.md
+++ b/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/x002bx002ba_-_b--.md
@@ -43,7 +43,7 @@
                     "end": 3
                 },
                 "operatorToken": {
-                    "kind": 100915,
+                    "kind": 134318643,
                     "flags": 64,
                     "start": 3,
                     "end": 5

--- a/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/x007b_ax005b5x005d_6_x007bx007d_x002bx002bb-new_x0028-5x0029x0028x0029_x007d_cx0028x0029x002elx002bx002b.md
+++ b/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/x007b_ax005b5x005d_6_x007bx007d_x002bx002bb-new_x0028-5x0029x0028x0029_x007d_cx0028x0029x002elx002bx002b.md
@@ -105,7 +105,7 @@
                                 "end": 16
                             },
                             "operatorToken": {
-                                "kind": 100915,
+                                "kind": 134318643,
                                 "flags": 64,
                                 "start": 16,
                                 "end": 17
@@ -123,7 +123,7 @@
                                     "expression": {
                                         "kind": 126,
                                         "operandToken": {
-                                            "kind": 100915,
+                                            "kind": 134318643,
                                             "flags": 64,
                                             "start": 22,
                                             "end": 23

--- a/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/x_x003d_-1_x003cx0021--x_.md
+++ b/test/__snapshot__/parser/miscellaneous/should-pass/gen/stand-alone/x_x003d_-1_x003cx0021--x_.md
@@ -39,7 +39,7 @@ x = -1 <!--x;
                 "right": {
                     "kind": 126,
                     "operandToken": {
-                        "kind": 100915,
+                        "kind": 134318643,
                         "flags": 64,
                         "start": 3,
                         "end": 5

--- a/test/__snapshot__/parser/module/top-level-await/unambiguous-ambiguous-allowAwaitOutsideFunction.md
+++ b/test/__snapshot__/parser/module/top-level-await/unambiguous-ambiguous-allowAwaitOutsideFunction.md
@@ -104,7 +104,7 @@ await / 0 /u
                 "expression": {
                     "kind": 126,
                     "operandToken": {
-                        "kind": 100915,
+                        "kind": 134318643,
                         "flags": 64,
                         "start": 24,
                         "end": 26

--- a/test/__snapshot__/parser/statements/for-await/binary.md
+++ b/test/__snapshot__/parser/statements/for-await/binary.md
@@ -63,7 +63,7 @@ a + b - c
                         "end": 5
                     },
                     "operatorToken": {
-                        "kind": 100915,
+                        "kind": 134318643,
                         "flags": 64,
                         "start": 5,
                         "end": 7

--- a/test/__snapshot__/parser/statements/for-in/binary.md
+++ b/test/__snapshot__/parser/statements/for-in/binary.md
@@ -63,7 +63,7 @@ a + b - c
                         "end": 5
                     },
                     "operatorToken": {
-                        "kind": 100915,
+                        "kind": 134318643,
                         "flags": 64,
                         "start": 5,
                         "end": 7

--- a/test/__snapshot__/parser/statements/for-of/binary.md
+++ b/test/__snapshot__/parser/statements/for-of/binary.md
@@ -63,7 +63,7 @@ a + b - c
                         "end": 5
                     },
                     "operatorToken": {
-                        "kind": 100915,
+                        "kind": 134318643,
                         "flags": 64,
                         "start": 5,
                         "end": 7

--- a/test/__snapshot__/parser/statements/for/nested-continue-and-labels.md
+++ b/test/__snapshot__/parser/statements/for/nested-continue-and-labels.md
@@ -333,7 +333,7 @@ function relativeComplement() {
                                                                                 "expression": {
                                                                                     "kind": 126,
                                                                                     "operandToken": {
-                                                                                        "kind": 100915,
+                                                                                        "kind": 134318643,
                                                                                         "flags": 64,
                                                                                         "start": 212,
                                                                                         "end": 214

--- a/test/__snapshot__/parser/statements/switch/valid-switch-cases.md
+++ b/test/__snapshot__/parser/statements/switch/valid-switch-cases.md
@@ -1698,7 +1698,7 @@ switch (answer) { case 0: let a; };
                                             "end": 587
                                         },
                                         "operatorToken": {
-                                            "kind": 100915,
+                                            "kind": 134318643,
                                             "flags": 64,
                                             "start": 587,
                                             "end": 603


### PR DESCRIPTION
This improves the arrow function type parsing. It require lots of tests because there are no lookaheads involved.