### PR TITLE
chore: add linting as public API

### DIFF
--- a/src/kataw.ts
+++ b/src/kataw.ts
@@ -221,27 +221,49 @@ export function print(root: any, options?: PrinterOptions): string {
   return printSource(root, options);
 }
 
-export function lintScript(source: string, options?: LinterOptions): RootNode {
+export function lintScript(
+  source: string,
+  reporter: (
+    diagnosticSource: DiagnosticSource,
+    kind: DiagnosticKind,
+    message: string,
+    start: number,
+    end: number,
+    source: string
+  ) => void,
+  options?: LinterOptions
+): RootNode {
   return parse(
     source,
     /* filename */ '__root__',
     Context.TopLevel,
     /* isModule */ false,
     function (diagnosticSource: DiagnosticSource, kind: DiagnosticKind, message: string, start: number, end: number) {
-      aladdin(diagnosticSource, kind, message, start, end, source);
+      reporter(diagnosticSource, kind, message, start, end, source);
     },
     { lint: options }
   );
 }
 
-export function lintModule(source: string, options?: LinterOptions): RootNode {
+export function lintModule(
+  source: string,
+  reporter: (
+    diagnosticSource: DiagnosticSource,
+    kind: DiagnosticKind,
+    message: string,
+    start: number,
+    end: number,
+    source: string
+  ) => void,
+  options?: LinterOptions
+): RootNode {
   return parse(
     source,
     '__root__',
     Context.Module | Context.TopLevel | Context.Strict | Context.AllowImportMeta,
     /* isModule */ true,
     function (diagnosticSource: DiagnosticSource, kind: DiagnosticKind, message: string, start: number, end: number) {
-      aladdin(diagnosticSource, kind, message, start, end, source);
+      reporter(diagnosticSource, kind, message, start, end, source);
     },
     { lint: options }
   );

--- a/src/kataw.ts
+++ b/src/kataw.ts
@@ -1,4 +1,4 @@
-import { parse, Options, LinterOptions } from './parser/parser';
+import { parse, Options, LinterRules, LinterOptions } from './parser/parser';
 import { DiagnosticSource, DiagnosticKind } from './diagnostic/diagnostic';
 import { PrinterOptions } from './printer';
 import { Context, OnError } from './parser/common';
@@ -220,51 +220,29 @@ export function print(root: any, options?: PrinterOptions): string {
   return printSource(root, options);
 }
 
-export function lintScript(
-  source: string,
-  reporter: (
-    diagnosticSource: DiagnosticSource,
-    kind: DiagnosticKind,
-    message: string,
-    start: number,
-    end: number,
-    source: string
-  ) => void,
-  options?: LinterOptions
-): RootNode {
+export function lintScript(source: string, options: LinterOptions, lint: LinterRules): RootNode {
   return parse(
     source,
     /* filename */ '__root__',
     Context.TopLevel,
     /* isModule */ false,
     function (diagnosticSource: DiagnosticSource, kind: DiagnosticKind, message: string, start: number, end: number) {
-      reporter(diagnosticSource, kind, message, start, end, source);
+      options.reporter(diagnosticSource, kind, message, start, end, source);
     },
-    { lint: options }
+    { lint }
   );
 }
 
-export function lintModule(
-  source: string,
-  reporter: (
-    diagnosticSource: DiagnosticSource,
-    kind: DiagnosticKind,
-    message: string,
-    start: number,
-    end: number,
-    source: string
-  ) => void,
-  options?: LinterOptions
-): RootNode {
+export function lintModule(source: string, options: LinterOptions, lint: LinterRules): RootNode {
   return parse(
     source,
     '__root__',
     Context.Module | Context.TopLevel | Context.Strict | Context.AllowImportMeta,
     /* isModule */ true,
     function (diagnosticSource: DiagnosticSource, kind: DiagnosticKind, message: string, start: number, end: number) {
-      reporter(diagnosticSource, kind, message, start, end, source);
+      options.reporter(diagnosticSource, kind, message, start, end, source);
     },
-    { lint: options }
+    { lint }
   );
 }
 

--- a/src/kataw.ts
+++ b/src/kataw.ts
@@ -1,7 +1,10 @@
-import { parse, Options } from './parser/parser';
-import { PrinterOptions, printSource } from './printer';
+import { parse, Options, LinterOptions } from './parser/parser';
+import { DiagnosticSource, DiagnosticKind } from './diagnostic/diagnostic';
+import { aladdin } from './reporter/aladdin';
+import { PrinterOptions } from './printer';
 import { Context, OnError } from './parser/common';
 import { RootNode } from './ast/root-node';
+import { printSource } from './printer';
 export { SyntaxKind } from './ast/syntax-node';
 export { NodeFlags } from './ast/syntax-node';
 export { TokenSyntaxKind, createToken, SyntaxToken } from './ast/token';
@@ -108,12 +111,16 @@ export { createConditionalExpression } from './ast/expressions/conditional-expr'
 export { createBinaryExpression } from './ast/expressions/binary-expr';
 export { createSubtractionType } from './ast/types/subtraction-type';
 export { createIndexedAccessType } from './ast/types/indexed-access-type';
+export { createTypeSpreadProperty } from './ast/types/type-spread-property';
+export { createInternalSlot } from './ast/types/internal-slot';
 export { createArrayType } from './ast/types/array-type';
 export { createTypeofType } from './ast/types/typeof-type';
 export { createNullableType } from './ast/types/nullable-type';
 export { createObjectType } from './ast/types/object-type';
 export { createStringType } from './ast/types/string-type';
 export { createNumberType } from './ast/types/number-type';
+export { createCallSignature } from './ast/types/call-signature';
+export { createIndexSignatureDeclaration } from './ast/types/index-signature-declaration';
 export { createIntersectionType } from './ast/types/intersection-type';
 export { createUnionType } from './ast/types/union-type';
 export { createTypeAnnotation } from './ast/types/type-annotation';
@@ -141,9 +148,10 @@ export { createFunctionDeclaration } from './ast/statements/function-declaration
 export { createDummyIdentifier } from './ast/internal/dummy-identifier';
 export { getLeadingComments, getTrailingComments } from './parser/scanner/comments';
 export { visitEachChild, visitNodes, visitNode } from './visitor';
-export { removeKatawTypes } from './transform/core';
-export { createUniqueIdentifier, UniqueIdentifierFlags } from './ast/internal/unique-identifier';
+export { createUniqueIdentifier } from './ast/internal/unique-identifier';
 export { fuzzModule, fuzzScript } from './fuzzer/';
+export { aladdin } from './reporter/aladdin';
+export { listing } from './reporter/listing';
 export {
   isStatementNode,
   isExpressionNode,
@@ -211,6 +219,32 @@ export function parseModule(source: string, options?: Options, onError?: OnError
 
 export function print(root: any, options?: PrinterOptions): string {
   return printSource(root, options);
+}
+
+export function lintScript(source: string, options?: LinterOptions): RootNode {
+  return parse(
+    source,
+    /* filename */ '__root__',
+    Context.TopLevel,
+    /* isModule */ false,
+    function (diagnosticSource: DiagnosticSource, kind: DiagnosticKind, message: string, start: number, end: number) {
+      aladdin(diagnosticSource, kind, message, start, end, source);
+    },
+    { lint: options }
+  );
+}
+
+export function lintModule(source: string, options?: LinterOptions): RootNode {
+  return parse(
+    source,
+    '__root__',
+    Context.Module | Context.TopLevel | Context.Strict | Context.AllowImportMeta,
+    /* isModule */ true,
+    function (diagnosticSource: DiagnosticSource, kind: DiagnosticKind, message: string, start: number, end: number) {
+      aladdin(diagnosticSource, kind, message, start, end, source);
+    },
+    { lint: options }
+  );
 }
 
 export function printScript(source: string, options?: PrinterOptions): string {

--- a/src/kataw.ts
+++ b/src/kataw.ts
@@ -1,6 +1,5 @@
 import { parse, Options, LinterOptions } from './parser/parser';
 import { DiagnosticSource, DiagnosticKind } from './diagnostic/diagnostic';
-import { aladdin } from './reporter/aladdin';
 import { PrinterOptions } from './printer';
 import { Context, OnError } from './parser/common';
 import { RootNode } from './ast/root-node';

--- a/src/parser/common.ts
+++ b/src/parser/common.ts
@@ -71,7 +71,7 @@ export const enum Context {
   Lint = 1 << 29
 }
 
-export const enum LinterRules {
+export const enum LinterFlags {
   None = 0,
   NoCatchAssign = 1 << 0, // Disallow assignment operators in catch statement
   NoCommaOperator = 1 << 1,
@@ -189,7 +189,7 @@ export const enum ScopeFlags {
 export interface ParserState {
   source: string;
   nodeFlags: NodeFlags;
-  linterRules: LinterRules;
+  linterFlags: LinterFlags;
   curPos: number;
   pos: number;
   token: any;

--- a/src/reporter/common.ts
+++ b/src/reporter/common.ts
@@ -46,7 +46,11 @@ export function getLineNumber(src: string, pos: number) {
 export function diagnosticColor(kind: DiagnosticKind): any {
   switch (kind) {
     case DiagnosticKind.Hint:
+<<<<<<< HEAD
     case DiagnosticKind.Linter:
+=======
+    case DiagnosticKind.Lint:
+>>>>>>> 38ddf5c17d (chore: add linting as public APO)
       return ColorCodes.Green;
     case DiagnosticKind.Error:
       return ColorCodes.Red;

--- a/src/reporter/common.ts
+++ b/src/reporter/common.ts
@@ -46,11 +46,7 @@ export function getLineNumber(src: string, pos: number) {
 export function diagnosticColor(kind: DiagnosticKind): any {
   switch (kind) {
     case DiagnosticKind.Hint:
-<<<<<<< HEAD
-    case DiagnosticKind.Linter:
-=======
     case DiagnosticKind.Lint:
->>>>>>> 38ddf5c17d (chore: add linting as public APO)
       return ColorCodes.Green;
     case DiagnosticKind.Error:
       return ColorCodes.Red;

--- a/src/reporter/listing.ts
+++ b/src/reporter/listing.ts
@@ -3,7 +3,11 @@ import { ColorCodes } from './common';
 
 export function diagnosticColor1(kind: DiagnosticKind): string {
   switch (kind) {
+<<<<<<< HEAD
     case DiagnosticKind.Linter:
+=======
+    case DiagnosticKind.Lint:
+>>>>>>> 38ddf5c17d (chore: add linting as public APO)
       return ColorCodes.Green + ' lint ' + ColorCodes.Reset;
     case DiagnosticKind.Error:
       return ColorCodes.Red + ' error ' + ColorCodes.Reset;

--- a/src/reporter/listing.ts
+++ b/src/reporter/listing.ts
@@ -3,11 +3,7 @@ import { ColorCodes } from './common';
 
 export function diagnosticColor1(kind: DiagnosticKind): string {
   switch (kind) {
-<<<<<<< HEAD
-    case DiagnosticKind.Linter:
-=======
     case DiagnosticKind.Lint:
->>>>>>> 38ddf5c17d (chore: add linting as public APO)
       return ColorCodes.Green + ' lint ' + ColorCodes.Reset;
     case DiagnosticKind.Error:
       return ColorCodes.Red + ' error ' + ColorCodes.Reset;


### PR DESCRIPTION
as requested by @aladdin-add this PR implements linting as public API. Linting can now be done like this

```ts
import { lintModule, aladdin } from 'kataw';

lintModule('eval', /* reporter */ aladdin,  { noEval: true});
```
or

```ts
import { lintScript, aladdin } from 'kataw';

lintScript('eval', /* reporter */ aladdin,  { noEval: true});
```

The 'reporter' argument gives the option to add any reporters and end-users can make their own reporter.

I tried to figure out how Babel does this, but I failed in my research.

**Note** This PR is blocked by #160 

This is how it looks like on the command line with the `aladdin` reporter

![aladdin](https://user-images.githubusercontent.com/31855118/127084887-19cc2eb3-cc08-4888-af51-ebadcbb4b0f3.png)
